### PR TITLE
Refactor: streamline IR expression and statement evaluation logic

### DIFF
--- a/rvrs-lang.cabal
+++ b/rvrs-lang.cabal
@@ -36,6 +36,9 @@ executable rvrs
 
   default-language:    Haskell2010
 
+  default-extensions:
+    LambdaCase
+
 -- === Executable: RunAll ===
 executable RunAll
   main-is:             RunAll.hs
@@ -72,6 +75,9 @@ executable RunAll
 
   default-language:    Haskell2010
 
+  default-extensions:
+    LambdaCase
+
 -- === Executable: TestLower ===
 executable TestLower
   main-is:             TestLower.hs
@@ -104,6 +110,9 @@ executable TestLower
     , mtl
 
   default-language:    Haskell2010
+
+  default-extensions:
+    LambdaCase
 
 -- === Executable: RunIRTests ===
 executable RunIRTests
@@ -139,3 +148,6 @@ executable RunIRTests
     , mtl
 
   default-language:    Haskell2010
+
+  default-extensions:
+    LambdaCase

--- a/src/RVRS/Eval/EvalExpr.hs
+++ b/src/RVRS/Eval/EvalExpr.hs
@@ -11,83 +11,65 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.IO.Class (liftIO)
 import Data.Maybe (fromMaybe)
+import Data.Traversable
 
 -- Evaluate expressions
 
 binOp :: (Double -> Double -> Double) -> ExprIR -> ExprIR -> EvalIR Value
-binOp op a b = do
-  v1 <- evalIRExpr a
-  v2 <- evalIRExpr b
-  case (v1, v2) of
-    (VNum n1, VNum n2) -> return $ VNum (op n1 n2)
-    _ -> throwError $ RuntimeError "Type error in arithmetic operation"
+binOp op a b = (,) <$> evalIRExpr a <*> evalIRExpr b >>= \case
+  (VNum n1, VNum n2) -> return $ VNum (op n1 n2)
+  _ -> throwError $ RuntimeError "Type error in arithmetic operation"
 
 evalIRExpr :: ExprIR -> EvalIR Value
 evalIRExpr expr = case expr of
-  IRNumLit n     -> return $ VNum n
-  IRStrLit s     -> return $ VStr s
-  IRBoolLit b    -> return $ VBool b
+  IRNumLit n  -> return $ VNum n
+  IRStrLit s  -> return $ VStr s
+  IRBoolLit b -> return $ VBool b
 
-  IRVar name -> do
-    env <- get
-    case Map.lookup name env of
-      Just v  -> return v
-      Nothing -> throwError $ RuntimeError ("Unbound variable: " ++ name)
+  IRVar name ->
+    Map.lookup name <$> get
+      >>= maybe (throwError . RuntimeError $ "Unbound variable: " ++ name) pure
 
   IRAdd a b -> binOp (+) a b
   IRSub a b -> binOp (-) a b
   IRMul a b -> binOp (*) a b
 
-  IRDiv a b -> do
-    v1 <- evalIRExpr a
-    v2 <- evalIRExpr b
-    case (v1, v2) of
-      (VNum _, VNum 0)      -> throwError $ RuntimeError "Division by zero"
-      (VNum n1, VNum n2)    -> return $ VNum (n1 / n2)
-      _                     -> throwError $ RuntimeError "Type error in division"
+  IRDiv a b ->
+    (,) <$> evalIRExpr a <*> evalIRExpr b >>= \case
+      (VNum _, VNum 0)   -> throwError $ RuntimeError "Division by zero"
+      (VNum n1, VNum n2) -> return $ VNum (n1 / n2)
+      _                  -> throwError $ RuntimeError "Type error in division"
 
-  IRNeg e -> do
-    v <- evalIRExpr e
-    case v of
+  IRNeg e ->
+    evalIRExpr e >>= \case
       VNum n -> return $ VNum (-n)
       _      -> throwError $ RuntimeError "Negation requires number"
 
-  IRNot e -> do
-    v <- evalIRExpr e
-    case v of
+  IRNot e ->
+    evalIRExpr e >>= \case
       VBool b -> return $ VBool (not b)
       _       -> throwError $ RuntimeError "Expected boolean in 'not'"
 
-  IREquals a b -> do
-    v1 <- evalIRExpr a
-    v2 <- evalIRExpr b
-    return $ VBool (v1 == v2)
+  IREquals a b ->
+    VBool <$> ((==) <$> evalIRExpr a <*> evalIRExpr b)
 
-  IRGreaterThan a b -> do
-    v1 <- evalIRExpr a
-    v2 <- evalIRExpr b
-    case (v1, v2) of
+  IRGreaterThan a b ->
+    (,) <$> evalIRExpr a <*> evalIRExpr b >>= \case
       (VNum n1, VNum n2) -> return $ VBool (n1 > n2)
       _ -> throwError $ RuntimeError "> requires numeric values"
 
-  IRLessThan a b -> do
-    v1 <- evalIRExpr a
-    v2 <- evalIRExpr b
-    case (v1, v2) of
+  IRLessThan a b ->
+    (,) <$> evalIRExpr a <*> evalIRExpr b >>= \case
       (VNum n1, VNum n2) -> return $ VBool (n1 < n2)
       _ -> throwError $ RuntimeError "< requires numeric values"
 
-  IRAnd a b -> do
-    v1 <- evalIRExpr a
-    v2 <- evalIRExpr b
-    case (v1, v2) of
+  IRAnd a b ->
+    (,) <$> evalIRExpr a <*> evalIRExpr b >>= \case
       (VBool b1, VBool b2) -> return $ VBool (b1 && b2)
       _ -> throwError $ RuntimeError "and requires booleans"
 
-  IROr a b -> do
-    v1 <- evalIRExpr a
-    v2 <- evalIRExpr b
-    case (v1, v2) of
+  IROr a b ->
+    (,) <$> evalIRExpr a <*> evalIRExpr b >>= \case
       (VBool b1, VBool b2) -> return $ VBool (b1 || b2)
       _ -> throwError $ RuntimeError "or requires booleans"
 
@@ -96,13 +78,10 @@ evalIRExpr expr = case expr of
     case Map.lookup name fsenv of
       Nothing -> throwError $ RuntimeError ("Unknown function: " ++ name)
       Just (FlowIR _ paramNames body) -> do
-        argVals <- mapM evalIRExpr args
+        argVals <- for args evalIRExpr
         if length paramNames /= length argVals
           then throwError $ RuntimeError ("Arity mismatch calling: " ++ name)
-          else do
-            let callEnv = Map.fromList (zip paramNames argVals)
-            (result, _) <- lift . lift $ runStateT (runReaderT (evalBody body) fsenv) callEnv
-            return $ fromMaybe VVoid result
+          else fromMaybe VVoid . fst <$> do callBody body . Map.fromList $ zip paramNames argVals
 
 -- Statement evaluator
 
@@ -119,62 +98,41 @@ evalIRStmt stmt = case stmt of
     return Nothing
 
   IRCallStmt name args -> do
-    flowMap <- ask
-    case Map.lookup name flowMap of
+    Map.lookup name <$> ask >>= \case
       Nothing -> throwError $ RuntimeError ("Unknown flow: " ++ name)
-      Just (FlowIR _ params body) -> do
-        argVals <- mapM evalIRExpr args
-        let callEnv = Map.fromList (zip params argVals)
-        _ <- lift . lift $ runStateT (runReaderT (evalBody body) flowMap) callEnv
-        return Nothing
+      Just (FlowIR _ params body) ->
+        Nothing <$ (for args evalIRExpr >>= callBody body . Map.fromList . zip params)
 
-  IRReturn expr -> do
-    val <- evalIRExpr expr
-    return (Just val)
+  IRReturn expr ->
+    Just <$> evalIRExpr expr
 
-  IRMouth expr -> do
-    val <- evalIRExpr expr
-    liftIO $ putStrLn ("mouth: " ++ show val)
-    return Nothing
+  IRMouth expr ->
+    Nothing <$ (evalIRExpr expr >>= liftIO . putStrLn . ("mouth: " ++) . show)
 
-  IRAssert expr -> do
-    val <- evalIRExpr expr
-    case val of
+  IRAssert expr ->
+    evalIRExpr expr >>= \case
       VBool True  -> return Nothing
       VBool False -> throwError $ RuntimeError "Assertion failed"
       _           -> throwError $ RuntimeError "Assert expects boolean"
 
-  IRBranch cond tBlock eBlock -> do
-    condVal <- evalIRExpr cond
-    let evalBlock [] = return Nothing
-        evalBlock (s:ss) = do
-          res <- evalIRStmt s
-          case res of
-            Just v  -> return (Just v)
-            Nothing -> evalBlock ss
-    case condVal of
-      VBool True  -> evalBlock tBlock
-      VBool False -> evalBlock eBlock
+  IRBranch cond tBlock eBlock ->
+    evalIRExpr cond >>= \case
+      VBool True  -> evalBody tBlock
+      VBool False -> evalBody eBlock
       _ -> throwError $ RuntimeError "Condition must be boolean"
 
-  IRDelta name expr _mType -> do
-    val <- evalIRExpr expr
-    modify (Map.insert name val)
-    return Nothing
+  IRDelta name expr _mType ->
+    Nothing <$ (evalIRExpr expr >>= modify . Map.insert name)
 
-  IRSource name expr _mType -> do
-    val <- evalIRExpr expr
-    env <- get
-    case Map.lookup name env of
-      Nothing -> modify (Map.insert name val) >> return Nothing
-      Just _  -> throwError $ RuntimeError ("Variable '" ++ name ++ "' already defined")
+  IRSource name expr _mType ->
+    Map.lookup name <$> get >>= \case
+      Nothing -> Nothing <$ (evalIRExpr expr >>= modify . Map.insert name)
+      Just _  -> throwError . RuntimeError $ "Variable '" ++ name ++ "' already defined"
+
+callBody :: [StmtIR] -> ValueEnv -> EvalIR (Maybe Value, ValueEnv)
+callBody body callEnv = runReaderT (evalBody body) <$> ask >>= lift . lift . flip runStateT callEnv
 
 -- Flow body evaluator used in both CallExpr and CallStmt
-
 evalBody :: [StmtIR] -> EvalIR (Maybe Value)
 evalBody [] = return Nothing
-evalBody (stmt:rest) = do
-  result <- evalIRStmt stmt
-  case result of
-    Just val -> return (Just val)
-    Nothing  -> evalBody rest
+evalBody (stmt:rest) = evalIRStmt stmt >>= maybe (evalBody rest) (pure . Just)


### PR DESCRIPTION
This PR, contributed by @iokasimov, refactors EvalIR logic for improved clarity, compactness, and maintainability. Key changes include:

- Replacing verbose do-notation with more expressive pattern matching via LambdaCase
- Consolidating binary and unary operations into cleaner evaluators
- Abstracting function call logic via callBody helper
- No changes to behavior — all existing tests pass

Thank you @iokasimov for this thoughtful and elegant improvement. Excited to continue collaborating!