### PR TITLE
docs: add module map and test directory guide

### DIFF
--- a/docs/module-map.md
+++ b/docs/module-map.md
@@ -1,0 +1,51 @@
+# 🌊 RVRS Module Map
+
+This document outlines the core modules of RVRS and their responsibilities. Use this map to understand how code flows through the system.
+
+---
+
+## 📦 Core Modules
+
+| Module | File | Purpose |
+|--------|------|---------|
+| `RVRS.Parser` | `src/RVRS/Parser/` | Parses RVRS source into AST form. Submodules handle expressions, statements, types, and imports. |
+| `RVRS.AST` | `src/RVRS/AST.hs` | Defines the high-level abstract syntax tree used by the parser. |
+| `RVRS.Lower` | `src/RVRS/Lower.hs` | Converts AST to IR (intermediate representation). |
+| `RVRS.IR` | `src/RVRS/IR.hs` | Defines intermediate representation used for evaluation and type checking. |
+| `RVRS.TypeCheck` | `src/RVRS/TypeCheck.hs` | Performs static analysis and ensures type correctness of IR. |
+| `RVRS.Env` | `src/RVRS/Env.hs` | Runtime environment definitions and variable bindings. |
+| `RVRS.Value` | `src/RVRS/Value.hs` | Core runtime value definitions (`VStr`, `VNum`, etc). |
+| `RVRS.Eval.*` | `src/RVRS/Eval/` | Evaluation of IR constructs. Split into `Expr`, `Stmt`, and `Flow` evaluators. |
+| `RVRS.Codegen` | `src/RVRS/Codegen.hs` | (Scaffolded) Future code generation target (e.g., Aiken). |
+| `RVRS.Pretty` | `src/RVRS/Pretty.hs` | Pretty-printing for diagnostics or output. |
+
+---
+
+## 🧪 Testing Modules
+
+| Module | File(s) | Purpose |
+|--------|---------|---------|
+| `Main.hs` | `app/Main.hs` | Entry point (placeholder or REPL, if enabled). |
+| `RunAll.hs` | `app/RunAll.hs` | Runs the full test suite. |
+| `RunIRTests.hs` | `app/RunIRTests.hs` | Runs IR-focused tests. |
+| `TestLower.hs` | `app/TestLower.hs` | (Optional) Verifies lowering correctness. |
+
+---
+
+## 🧱 Stdlib and Rituals
+
+| File | Purpose |
+|------|---------|
+| `stdlib/stdlib.rvrs` | Core prelude flows (standard rituals). |
+| `docs/Prelude_of_Rituals.md` | Documentation of the stdlib symbols. |
+
+---
+
+## 📁 Directory Layout Summary
+
+- `src/`: Source code
+- `tests/`: Test files grouped by purpose
+- `docs/`: Project documentation
+- `examples/`: Showcase or learning flows
+- `app/`: Executables and test runners
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,32 @@
+# 🧪 RVRS Tests
+
+RVRS uses categorized test files to validate parser, evaluation, type checking, and IR behavior.
+
+---
+
+## 🗂 Test Folder Structure
+
+- **`core/`** – Standard functionality (scoping, arithmetic, source/delta correctness)
+- **`poetic/`** – Language-ritual samples using the most symbolic features
+- **`regression/`** – Bugs or behaviors we've fixed and want to lock in
+- **`typecheck/`** – Type annotation pass/fail tests
+- **`ir/`** – Focused on IR evaluation and behavior
+- **`edge_cases/`** – Unusual or extreme examples to test robustness
+- **`flows/`** – Higher-level use cases or flow interactions
+- **`syntax/`** – Validates surface syntax parsing (e.g. `speaks`, `ceremony`, etc.)
+- **`debug_test.rvrs`** – Freeform sandbox file
+
+---
+
+## 🧪 How to Run Tests
+
+Use `cabal run RunAll` to run all test files.  
+Or `cabal run rvrs <file>` to run a specific test manually.
+
+---
+
+## 🧱 Philosophy
+
+If it's not tested, it's not real.  
+All new features or syntax extensions must be accompanied by one or more test cases.
+


### PR DESCRIPTION
This PR adds two new documentation files to support contributors and maintain project clarity:

- `docs/module-map.md`: An overview of all core RVRS modules, their purposes, and interconnections.
- `tests/README.md`: A structured guide to the RVRS test suite layout, category descriptions, and usage instructions.

These additions reinforce RVRS’s commitment to clarity, modularity, and contributor onboarding. No functional code changes are included in this PR.
