### PR TITLE
[WIP] Preparation to transit internal modules to Я

### DIFF
--- a/docs/dev-log.md
+++ b/docs/dev-log.md
@@ -83,7 +83,7 @@
 
 ---
 
-## 🧭 v0.5.0-alpha – Flow Arguments & Expression Calling  
+## 🧭 v0.5.0-alpha – Flow Arguments & Expr Calling  
 **📅 Date:** 2025-05-06  
 **🔖 Tag:** v0.5.0-alpha
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -62,7 +62,7 @@ These are poetic or expressive tools that may evolve post-v1:
 | `veil`      | Optional or hidden logic             | `Maybe` / planned     |
 | `tide`      | Iterate over a sequence              | `for` / planned       |
 | `stream`    | Represents a flowing list            | `List` / placeholder  |
-| `chant`     | Symbolic transformation              | Expression macro?     |
+| `chant`     | Symbolic transformation              | Expr macro?     |
 | `glyph`     | User-defined symbolic type           | `type` / long-term    |
 | `ritual`    | Named reusable block/module          | Planned               |
 

--- a/rvrs-lang.cabal
+++ b/rvrs-lang.cabal
@@ -24,6 +24,7 @@ executable rvrs
     , RVRS.IR
     , RVRS.Lower
     , RVRS.Env
+    , RVRS.Utils
 
   build-depends:
       base >=4.14 && <5
@@ -60,6 +61,7 @@ executable RunAll
     , RVRS.IR
     , RVRS.Lower
     , RVRS.Env
+    , RVRS.Utils
 
   build-depends:
       base >=4.14 && <5
@@ -99,6 +101,7 @@ executable TestLower
     , RVRS.IR
     , RVRS.Lower
     , RVRS.Env
+    , RVRS.Utils
 
   build-depends:
       base >=4.14 && <5
@@ -135,6 +138,7 @@ executable RunIRTests
     , RVRS.IR
     , RVRS.Lower
     , RVRS.Env
+    , RVRS.Utils
 
   build-depends:
       base >=4.14 && <5

--- a/src/RVRS/AST.hs
+++ b/src/RVRS/AST.hs
@@ -1,5 +1,6 @@
--- src/RVRS/AST.hs
-
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE UndecidableInstances #-}
 module RVRS.AST where
 
 import RVRS.Parser.Type (RVRSType(..))
@@ -21,41 +22,39 @@ data Argument = Argument
 
 -- | Statements inside a flow block
 data Statement
-  = Source String (Maybe RVRSType) Expr                 -- source x = ...
-  | Delta String (Maybe RVRSType) Expr
-  | Branch Expr [Statement] [Statement]-- branch cond { ... } else { ... }
-  | Mouth Expr                          -- mouth "..."
-  | Whisper Expr
-  | Echo Expr                           -- echo x
-  | Pillar String Expr  -- pillar NAME = ...
-  | Return Expr
-  | Call String [Expr]
-  | Assert Expr
+  = Source String (Maybe RVRSType) (Recursive Expr)                 -- source x = ...
+  | Delta String (Maybe RVRSType) (Recursive Expr)
+  | Branch (Recursive Expr) [Statement] [Statement]-- branch cond { ... } else { ... }
+  | Mouth (Recursive Expr)                          -- mouth "..."
+  | Whisper (Recursive Expr)
+  | Echo (Recursive Expr)                           -- echo x
+  | Pillar String (Recursive Expr)  -- pillar NAME = ...
+  | Return (Recursive Expr)
+  | Call String [Recursive Expr]
+  | Assert (Recursive Expr)
 
   deriving (Show, Eq)
 
-
-data Expr
-  = Var String                          -- x
-  | StrLit String                       -- "hello"
-  | BoolLit Bool                        -- true, false
-  | Equals Expr Expr                    -- a == b
-  | GreaterThan Expr Expr              -- a > b
-  | LessThan Expr Expr                 -- a < b
-  | Add Expr Expr
-  | Sub Expr Expr
-  | Mul Expr Expr
-  | Div Expr Expr
+data Expr e
+  = Var String
+  | StrLit String
+  | BoolLit Bool
+  | Equals e e
+  | GreaterThan e e
+  | LessThan e e
+  | Add e e
+  | Sub e e
+  | Mul e e
+  | Div e e
   | NumLit Double
-  | Not Expr     
-  | And Expr Expr   
-  | Or Expr Expr 
-  | CallExpr String [Expr]   
-  | Neg Expr 
-  
-  
-  
+  | Not e
+  | And e e
+  | Or e e
+  | CallExpr String [e]
+  | Neg e
   deriving (Show, Eq)
 
+newtype Recursive f = Recursive { unfix :: f (Recursive f) }
 
-  
+deriving instance (Eq (f (Recursive f))) => Eq (Recursive f)
+deriving instance (Show (f (Recursive f))) => Show (Recursive f)

--- a/src/RVRS/Codegen.hs
+++ b/src/RVRS/Codegen.hs
@@ -25,14 +25,14 @@ genStmt stmt = case stmt of
     ["}"]
 
 -- | Convert an expression into Aiken-compatible syntax
-genExpr :: Expr -> String
+genExpr :: Recursive Expr -> String
 genExpr expr = case expr of
-  Var x         -> x
-  StrLit s      -> show s
-  BoolLit True  -> "true"
-  BoolLit False -> "false"
-  Equals a b    -> genExpr a ++ " == " ++ genExpr b
-  
+  Recursive (Var x)         -> x
+  Recursive (StrLit s)      -> show s
+  Recursive (BoolLit True)  -> "true"
+  Recursive (BoolLit False) -> "false"
+  Recursive (Equals a b)    -> genExpr a ++ " == " ++ genExpr b
+
 
 -- | Render a function argument
 renderArg :: Argument -> String

--- a/src/RVRS/Eval.hs
+++ b/src/RVRS/Eval.hs
@@ -2,12 +2,12 @@
 module RVRS.Eval (
   evalIRExpr,
   evalIRStmt,
-  evalStmtsWithEnv,
+  evalBody,
   evalIRFlow,
   runEvalIR,
   EvalError(..)
 ) where
 
-import RVRS.Eval.EvalExpr (evalIRExpr)
-import RVRS.Eval.EvalStmt (evalIRStmt, evalStmtsWithEnv)
+import RVRS.Eval.EvalExpr (evalIRExpr, evalBody)
+import RVRS.Eval.EvalStmt (evalIRStmt)
 import RVRS.Eval.EvalFlow (evalIRFlow, runEvalIR, EvalError(..))

--- a/src/RVRS/Eval/EvalFlow.hs
+++ b/src/RVRS/Eval/EvalFlow.hs
@@ -1,8 +1,9 @@
 module RVRS.Eval.EvalFlow (evalIRFlow, runEvalIR, EvalError(..)) where
 
 import RVRS.IR
+import RVRS.Utils
 import RVRS.Value (Value(..))
-import RVRS.Eval.EvalStmt (evalStmtsWithEnv)
+import RVRS.Eval.EvalExpr (evalBody)
 import RVRS.Eval.Types (EvalIR, EvalError(..))  
 import qualified Data.Map as Map
 import Control.Monad.Except
@@ -15,11 +16,9 @@ import qualified RVRS.AST as AST
 
 -- Load stdlib and merge
 loadAndMergeStdlib :: IO (Map.Map String FlowIR)
-loadAndMergeStdlib = do
-  src <- readFile "stdlib/stdlib.rvrs"
-  case parseRVRS src of
-    Left err -> error $ "Stdlib parse error:\n" ++ show err
-    Right flows -> return $ Map.fromList [(AST.flowName f, lowerFlow f) | f <- flows]
+loadAndMergeStdlib = parseRVRS <$> readFile "stdlib/stdlib.rvrs" >>= \case
+  Left err -> error $ "Stdlib parse error:\n" ++ show err
+  Right flows -> return $ Map.fromList $ (,) <$> AST.flowName <*> lowerFlow <$> flows
 
 -- Runner
 runEvalIR :: Map.Map String FlowIR -> Map.Map String Value -> EvalIR a -> IO (Either EvalError (a, Map.Map String Value))
@@ -29,15 +28,13 @@ runEvalIR flows env action =
 -- Flow evaluation
 evalIRFlow :: Map.Map String FlowIR -> String -> [Value] -> IO (Either EvalError (Maybe Value))
 evalIRFlow userFlows entryName args = do
-  stdlibFlows <- loadAndMergeStdlib
-  let fullFlowMap = Map.union userFlows stdlibFlows
+  fullFlowMap <- Map.union userFlows <$> loadAndMergeStdlib
   case Map.lookup entryName fullFlowMap of
     Just (FlowIR _ params body) -> do
       let initialEnv = Map.fromList (zip params args)
-      result <- runEvalIR fullFlowMap initialEnv $ catchError (evalStmtsWithEnv body) handleReturn
-      return $ fmap fst result
-    Nothing -> return $ Left (RuntimeError $ "No flow named '" ++ entryName ++ "' found.")
-  where
-    handleReturn :: EvalError -> EvalIR (Maybe Value)
-    handleReturn (Return v) = return (Just v)
-    handleReturn err        = throwError err
+      fst <$$> do runEvalIR fullFlowMap initialEnv $ catchError (evalBody body) handleReturn
+    Nothing -> return $ Left . RuntimeError $ "No flow named '" ++ entryName ++ "' found."
+
+handleReturn :: EvalError -> EvalIR (Maybe Value)
+handleReturn (Return v) = return (Just v)
+handleReturn err        = throwError err

--- a/src/RVRS/IR.hs
+++ b/src/RVRS/IR.hs
@@ -49,3 +49,21 @@ data ExprIR
   -- Function call within an expression: foo(x, y)
   | IRCallExpr String [ExprIR]
   deriving (Show, Eq)
+
+-- data Expr
+  -- = Var String                          -- x
+  -- | StrLit String                       -- "hello"
+  -- | BoolLit Bool                        -- true, false
+  -- | Equals Expr Expr                    -- a == b
+  -- | GreaterThan Expr Expr              -- a > b
+  -- | LessThan Expr Expr                 -- a < b
+  -- | Add Expr Expr
+  -- | Sub Expr Expr
+  -- | Mul Expr Expr
+  -- | Div Expr Expr
+  -- | NumLit Double
+  -- | Not Expr     
+  -- | And Expr Expr   
+  -- | Or Expr Expr 
+  -- | CallExpr String [Expr]   
+  -- | Neg Expr 

--- a/src/RVRS/Lower.hs
+++ b/src/RVRS/Lower.hs
@@ -33,21 +33,21 @@ lowerStmt stmt = case stmt of
   AST.Pillar name expr         -> IR.IRWhisper name (lowerExpr expr)  -- fallback
 
 -- | Lower an AST Expr into IR
-lowerExpr :: AST.Expr -> IR.ExprIR
+lowerExpr :: AST.Recursive AST.Expr -> IR.ExprIR
 lowerExpr expr = case expr of
-  AST.Var name         -> IR.IRVar name
-  AST.StrLit s         -> IR.IRStrLit s
-  AST.NumLit n         -> IR.IRNumLit n
-  AST.BoolLit b        -> IR.IRBoolLit b
-  AST.Add a b          -> IR.IRAdd (lowerExpr a) (lowerExpr b)
-  AST.Sub a b          -> IR.IRSub (lowerExpr a) (lowerExpr b)
-  AST.Mul a b          -> IR.IRMul (lowerExpr a) (lowerExpr b)
-  AST.Div a b          -> IR.IRDiv (lowerExpr a) (lowerExpr b)
-  AST.Neg e            -> IR.IRNeg (lowerExpr e)
-  AST.Not e            -> IR.IRNot (lowerExpr e)
-  AST.And a b          -> IR.IRAnd (lowerExpr a) (lowerExpr b)
-  AST.Or a b           -> IR.IROr  (lowerExpr a) (lowerExpr b)
-  AST.Equals a b       -> IR.IREquals (lowerExpr a) (lowerExpr b)
-  AST.GreaterThan a b  -> IR.IRGreaterThan (lowerExpr a) (lowerExpr b)
-  AST.LessThan a b     -> IR.IRLessThan (lowerExpr a) (lowerExpr b)
-  AST.CallExpr name es -> IR.IRCallExpr name (map lowerExpr es)
+  AST.Recursive (AST.Var name)         -> IR.IRVar name
+  AST.Recursive (AST.StrLit s)         -> IR.IRStrLit s
+  AST.Recursive (AST.NumLit n)         -> IR.IRNumLit n
+  AST.Recursive (AST.BoolLit b)        -> IR.IRBoolLit b
+  AST.Recursive (AST.Add a b)          -> IR.IRAdd (lowerExpr a) (lowerExpr b)
+  AST.Recursive (AST.Sub a b)          -> IR.IRSub (lowerExpr a) (lowerExpr b)
+  AST.Recursive (AST.Mul a b)          -> IR.IRMul (lowerExpr a) (lowerExpr b)
+  AST.Recursive (AST.Div a b)          -> IR.IRDiv (lowerExpr a) (lowerExpr b)
+  AST.Recursive (AST.Neg e)            -> IR.IRNeg (lowerExpr e)
+  AST.Recursive (AST.Not e)            -> IR.IRNot (lowerExpr e)
+  AST.Recursive (AST.And a b)          -> IR.IRAnd (lowerExpr a) (lowerExpr b)
+  AST.Recursive (AST.Or a b)           -> IR.IROr  (lowerExpr a) (lowerExpr b)
+  AST.Recursive (AST.Equals a b)       -> IR.IREquals (lowerExpr a) (lowerExpr b)
+  AST.Recursive (AST.GreaterThan a b)  -> IR.IRGreaterThan (lowerExpr a) (lowerExpr b)
+  AST.Recursive (AST.LessThan a b)     -> IR.IRLessThan (lowerExpr a) (lowerExpr b)
+  AST.Recursive (AST.CallExpr name es) -> IR.IRCallExpr name (map lowerExpr es)

--- a/src/RVRS/Lower.hs
+++ b/src/RVRS/Lower.hs
@@ -16,7 +16,7 @@ mergeAndLower flows =
 -- | Convert a full Flow into IR
 lowerFlow :: AST.Flow -> IR.FlowIR
 lowerFlow (AST.Flow name args body) =
-  IR.FlowIR name (map AST.argName args) (map lowerStmt body)
+  IR.FlowIR name (AST.argName <$> args) (lowerStmt <$> body)
 
 -- | Lower an AST Statement into IR
 lowerStmt :: AST.Statement -> IR.StmtIR

--- a/src/RVRS/Parser/Type.hs
+++ b/src/RVRS/Parser/Type.hs
@@ -5,6 +5,7 @@ import Text.Megaparsec
 import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
 
+-- TODO: add TypeUnit
 -- The core type tags used for annotations
 data RVRSType
   = TypeNum

--- a/src/RVRS/Pretty.hs
+++ b/src/RVRS/Pretty.hs
@@ -2,23 +2,23 @@ module RVRS.Pretty (prettyExpr) where
 
 import RVRS.AST
 
-prettyExpr :: Expr -> String
+prettyExpr :: Recursive Expr -> String
 prettyExpr expr = case expr of
-  NumLit n     -> show n
-  BoolLit True -> "truth"
-  BoolLit False -> "void"
-  StrLit s     -> show s
-  Var name     -> name
+  Recursive (NumLit n) -> show n
+  Recursive (BoolLit True) -> "truth"
+  Recursive (BoolLit False) -> "void"
+  Recursive (StrLit s) -> show s
+  Recursive (Var name) -> name
 
-  Add e1 e2    -> "(" ++ prettyExpr e1 ++ " + " ++ prettyExpr e2 ++ ")"
-  Sub e1 e2    -> "(" ++ prettyExpr e1 ++ " - " ++ prettyExpr e2 ++ ")"
-  Mul e1 e2    -> "(" ++ prettyExpr e1 ++ " * " ++ prettyExpr e2 ++ ")"
-  Div e1 e2    -> "(" ++ prettyExpr e1 ++ " / " ++ prettyExpr e2 ++ ")"
+  -- Recursive (Add e1 e2) -> "(" ++ prettyExpr (Recursive e1) ++ " + " ++ prettyExpr (Recursive e2) ++ ")"
+  -- Recursive (Sub e1 e2) -> "(" ++ prettyExpr (Recursive e1) ++ " - " ++ prettyExpr (Recursive e2) ++ ")"
+  -- Recursive (Mul e1 e2) -> "(" ++ prettyExpr (Recursive e1) ++ " * " ++ prettyExpr (Recursive e2) ++ ")"
+  -- Recursive (Div e1 e2) -> "(" ++ prettyExpr (Recursive e1) ++ " / " ++ prettyExpr (Recursive e2) ++ ")"
 
-  Equals e1 e2 -> "(" ++ prettyExpr e1 ++ " == " ++ prettyExpr e2 ++ ")"
-  And e1 e2    -> "(" ++ prettyExpr e1 ++ " and " ++ prettyExpr e2 ++ ")"
-  Or e1 e2     -> "(" ++ prettyExpr e1 ++ " or " ++ prettyExpr e2 ++ ")"
-  Not e        -> "(not " ++ prettyExpr e ++ ")"
-  Neg e        -> "(-" ++ prettyExpr e ++ ")"
+  -- Recursive (Equals e1 e2) -> "(" ++ prettyExpr (Recursive e1) ++ " == " ++ prettyExpr (Recursive e2) ++ ")"
+  -- Recursive (And e1 e2) -> "(" ++ prettyExpr (Recursive e1) ++ " and " ++ prettyExpr (Recursive e2) ++ ")"
+  -- Recursive (Or e1 e2) -> "(" ++ prettyExpr (Recursive e1) ++ " or " ++ prettyExpr (Recursive e2) ++ ")"
+  -- Recursive (Not e) -> "(not " ++ prettyExpr (Recursive e) ++ ")"
+  -- Recursive (Neg e) -> "(-" ++ prettyExpr (Recursive e) ++ ")"
 
-  CallExpr name args -> "call " ++ name ++ "(" ++ unwords (map prettyExpr args) ++ ")"
+  -- Recursive (CallExpr name args) -> "call " ++ name ++ "(" ++ unwords (prettyExpr . Recursive <$> args) ++ ")"

--- a/src/RVRS/Utils.hs
+++ b/src/RVRS/Utils.hs
@@ -1,0 +1,6 @@
+module RVRS.Utils where
+
+infixl 4 <$$>
+
+(<$$>) :: (Functor t, Functor tt) => (a -> b) -> t (tt a) -> t (tt b)
+(<$$>) = (<$>) . (<$>)

--- a/tests/rvrs/regression/full_test.rvrs
+++ b/tests/rvrs/regression/full_test.rvrs
@@ -49,7 +49,7 @@ flow returnInsideBranch {
 }
 
 
--- 🧠 Expression, Logic, and Math
+-- 🧠 Expr, Logic, and Math
 
 flow expressionTest() {
   source x = 10 + 2 * 5 - 3 / 3


### PR DESCRIPTION
- [x] Redefine `Expr` as functor so it can be used recursively (`Recursive Expr`)
- [ ] Unify IR and ordinary AST datatypes (`ExprIR`/`Expr`, `StatementIR`/`Statement`)