### PR TITLE
Scaffolded initial typechecker with expression inference for literals and variables

### DIFF
--- a/rvrs-lang.cabal
+++ b/rvrs-lang.cabal
@@ -25,6 +25,8 @@ executable rvrs
     , RVRS.Lower
     , RVRS.Env
     , RVRS.Utils
+    , RVRS.Typecheck.Check
+    , RVRS.Typecheck.Types
 
   build-depends:
       base >=4.14 && <5
@@ -36,7 +38,6 @@ executable rvrs
     , mtl
 
   default-language:    Haskell2010
-
   default-extensions:
     LambdaCase
 
@@ -62,6 +63,8 @@ executable RunAll
     , RVRS.Lower
     , RVRS.Env
     , RVRS.Utils
+    , RVRS.Typecheck.Check
+    , RVRS.Typecheck.Types
 
   build-depends:
       base >=4.14 && <5
@@ -76,7 +79,6 @@ executable RunAll
     , mtl
 
   default-language:    Haskell2010
-
   default-extensions:
     LambdaCase
 
@@ -102,6 +104,8 @@ executable TestLower
     , RVRS.Lower
     , RVRS.Env
     , RVRS.Utils
+    , RVRS.Typecheck.Check
+    , RVRS.Typecheck.Types
 
   build-depends:
       base >=4.14 && <5
@@ -113,7 +117,6 @@ executable TestLower
     , mtl
 
   default-language:    Haskell2010
-
   default-extensions:
     LambdaCase
 
@@ -139,6 +142,8 @@ executable RunIRTests
     , RVRS.Lower
     , RVRS.Env
     , RVRS.Utils
+    , RVRS.Typecheck.Check
+    , RVRS.Typecheck.Types
 
   build-depends:
       base >=4.14 && <5
@@ -149,9 +154,9 @@ executable RunIRTests
     , containers
     , directory
     , filepath
+    , process
     , mtl
 
   default-language:    Haskell2010
-
   default-extensions:
     LambdaCase

--- a/src/RVRS/Typecheck/Check.hs
+++ b/src/RVRS/Typecheck/Check.hs
@@ -1,0 +1,16 @@
+module RVRS.Typecheck.Check where
+
+import RVRS.AST
+import RVRS.Typecheck.Types
+import qualified Data.Map as Map
+
+-- Infer the type of an expression
+typeOfExpr :: TypeEnv -> Expr a -> Either TypeError RVRS_Type
+typeOfExpr _ (NumLit _) = Right TNum
+typeOfExpr _ (StrLit _) = Right TStr
+typeOfExpr _ (BoolLit _) = Right TBool
+typeOfExpr env (Var name) =
+  case Map.lookup name env of
+    Just ty -> Right ty
+    Nothing -> Left (UnboundVariable name)
+typeOfExpr _ other = Left (UnsupportedExpr (show other))

--- a/src/RVRS/Typecheck/Types.hs
+++ b/src/RVRS/Typecheck/Types.hs
@@ -1,0 +1,18 @@
+module RVRS.Typecheck.Types where
+
+import qualified Data.Map as Map
+
+data RVRS_Type
+  = TNum
+  | TStr
+  | TBool
+  | TUnknown
+  deriving (Show, Eq)
+
+type TypeEnv = Map.Map String RVRS_Type
+
+data TypeError
+  = TypeMismatch RVRS_Type RVRS_Type
+  | UnknownVariable String
+  | UnsupportedOp String
+  deriving (Show, Eq)


### PR DESCRIPTION
Type Enforcement (Step 1): Basic Expression Inference

This PR introduces the initial scaffolding for the RVRS typechecker system.
It includes:

- RVRS.Typecheck.Types: Defines the type environment and error types

- RVRS.Typecheck.Check: Implements basic type inference for expressions

Supports literals: NumLit, StrLit, BoolLit

Supports variable lookup from the environment

Returns structured type errors (UnknownVariable, UnsupportedExpr)

This forms the foundation for future static checks on declarations (delta, source), control flow (branch), and overall flow validation.