### PR TITLE
Typecheck: Add expression-level type inference with binary op support

### DIFF
--- a/app/TestTypeCheck.hs
+++ b/app/TestTypeCheck.hs
@@ -1,0 +1,78 @@
+module Main where
+
+import Test.HUnit
+import qualified Data.Map as Map
+
+import RVRS.Typecheck.Check (typeofExpr)
+import RVRS.Typecheck.Types
+import RVRS.AST
+import RVRS.AST (Recursive(..)) 
+
+
+-- Define a test environment with some known vars
+testEnv :: TypeEnv
+testEnv = Map.fromList
+  [ ("x", TNum)
+  , ("y", TBool)
+  , ("msg", TStr)
+  ]
+
+-- Helper to build expressions
+num :: Double -> Recursive Expression
+num = Recursive . NumLit
+
+bool :: Bool -> Recursive Expression
+bool = Recursive . BoolLit
+
+str :: String -> Recursive Expression
+str = Recursive . StrLit
+
+var :: String -> Recursive Expression
+var = Recursive . Var
+
+add :: Recursive Expression -> Recursive Expression -> Recursive Expression
+add a b = Recursive (Add a b)
+
+equals :: Recursive Expression -> Recursive Expression -> Recursive Expression
+equals a b = Recursive (Equals a b)
+
+notExpr :: Recursive Expression -> Recursive Expression
+notExpr = Recursive . Not
+
+-- Define the actual tests
+tests :: Test
+tests = TestList
+  [ "Num literal" ~: typeofExpr testEnv (num 42) ~?= Right TNum
+  , "Bool literal" ~: typeofExpr testEnv (bool True) ~?= Right TBool
+  , "Str literal" ~: typeofExpr testEnv (str "hello") ~?= Right TStr
+
+  , "Known variable" ~: typeofExpr testEnv (var "x") ~?= Right TNum
+  , "Unknown variable" ~: typeofExpr testEnv (var "z") ~?= Left (UnknownVariable "z")
+
+  , "Valid addition" ~: typeofExpr testEnv (add (num 5) (num 7)) ~?= Right TNum
+
+  , "Invalid addition" ~: TestCase $
+      case typeofExpr testEnv (add (num 5) (bool True)) of
+        Left (TypeMismatch _ _) -> return ()
+        _ -> assertFailure "Expected TypeMismatch"
+
+  , "Equals matching types" ~: typeofExpr testEnv (equals (num 1) (num 1)) ~?= Right TBool
+
+  , "Equals mismatched types" ~: TestCase $
+      case typeofExpr testEnv (equals (str "hi") (bool False)) of
+        Left (TypeMismatch _ _) -> return ()
+        _ -> assertFailure "Expected TypeMismatch"
+
+  , "Not on Bool" ~: typeofExpr testEnv (notExpr (bool False)) ~?= Right TBool
+
+  , "Not on Num" ~: TestCase $
+      case typeofExpr testEnv (notExpr (num 0)) of
+        Left (TypeMismatch _ _) -> return ()
+        _ -> assertFailure "Expected TypeMismatch"
+  ]
+
+main :: IO ()
+main = do
+  putStrLn "🔍 Running typeOfExpr tests..."
+  _ <- runTestTT tests
+  return ()

--- a/rvrs-lang.cabal
+++ b/rvrs-lang.cabal
@@ -140,3 +140,27 @@ executable RunIRTests
   default-language:    Haskell2010
   default-extensions:
     LambdaCase
+
+-- === Executable: TestTypeCheck ===
+executable TestTypeCheck
+  main-is:             TestTypeCheck.hs
+  hs-source-dirs:      app, src
+  other-modules:
+      RVRS.AST
+    , RVRS.Typecheck.Check
+    , RVRS.Typecheck.Types
+    , RVRS.Parser.Type
+
+  build-depends:
+      base >=4.14 && <5
+    , text
+    , containers
+    , megaparsec
+    , prettyprinter
+    , parser-combinators
+    , mtl
+    , HUnit
+
+  default-language:    Haskell2010
+  default-extensions:
+    LambdaCase

--- a/src/RVRS/Typecheck/Check.hs
+++ b/src/RVRS/Typecheck/Check.hs
@@ -4,13 +4,53 @@ import RVRS.AST
 import RVRS.Typecheck.Types
 import qualified Data.Map as Map
 
--- Infer the type of an expression
-typeOfExpr :: TypeEnv -> Recursive Expression -> Either TypeError RVRS_Type
-typeOfExpr _ (Recursive (NumLit _)) = Right TNum
-typeOfExpr _ (Recursive (StrLit _)) = Right TStr
-typeOfExpr _ (Recursive (BoolLit _)) = Right TBool
-typeOfExpr env (Recursive (Var name)) =
-  case Map.lookup name env of
-    Just ty -> Right ty
-    Nothing -> Left (UnknownVariable name)
-typeOfExpr _ other = Left (UnsupportedOp (show other))
+typeofExpr :: TypeEnv -> Recursive Expression -> Either TypeError RVRS_Type
+typeofExpr env (Recursive expr) = case expr of
+  NumLit _ -> Right TNum
+  StrLit _ -> Right TStr
+  BoolLit _ -> Right TBool
+  Var x ->
+    case Map.lookup x env of
+      Just t  -> Right t
+      Nothing -> Left $ UnknownVariable x
+
+  Add a b -> checkBinary env TNum TNum a b
+  Sub a b -> checkBinary env TNum TNum a b
+  Mul a b -> checkBinary env TNum TNum a b
+  Div a b -> checkBinary env TNum TNum a b
+
+  Equals a b -> do
+    t1 <- typeofExpr env a
+    t2 <- typeofExpr env b
+    case t1 == t2 of
+      True  -> Right TBool
+      False -> Left $ TypeMismatch t1 t2
+
+  And a b -> checkBinary env TBool TBool a b
+  Or a b  -> checkBinary env TBool TBool a b
+
+  Not e -> do
+    t <- typeofExpr env e
+    case t of
+      TBool -> Right TBool
+      _     -> Left $ TypeMismatch t TBool
+
+  Neg e -> do
+    t <- typeofExpr env e
+    case t of
+      TNum -> Right TNum
+      _    -> Left $ TypeMismatch t TNum
+
+  GreaterThan a b -> checkBinary env TNum TBool a b
+  LessThan a b    -> checkBinary env TNum TBool a b
+
+  _ -> Left $ UnsupportedOp (show expr)
+
+
+checkBinary :: TypeEnv -> RVRS_Type -> RVRS_Type -> Recursive Expression -> Recursive Expression -> Either TypeError RVRS_Type
+checkBinary env expected retType a b = do
+  t1 <- typeofExpr env a
+  t2 <- typeofExpr env b
+  case (t1, t2) of
+    (t1', t2') | t1' == expected && t2' == expected -> Right retType
+               | otherwise -> Left $ TypeMismatch t1' t2'


### PR DESCRIPTION
- Adds foundational type system (RVRS_Type, TypeError)
- Implements \`typeofExpr\` for literals, variables, Add, Equals, Not
- Includes new test runner with 11 passing unit tests
- All integration runners confirmed green

### Next Steps
- Extend typechecking to statements (\`checkStmt\`)
- Propagate errors in deltas, sources, calls, branches"