### PR TITLE
docs: update all project documentation and add Ya README

### DIFF
--- a/docs/00_intro.md
+++ b/docs/00_intro.md
@@ -1,6 +1,6 @@
 # Introduction to RVRS
 
-RVRS (Rivers) is a symbolic smart contract language designed for the Cardano blockchain. It treats code not just as logic, but as ritual—something expressive, structured, and meaningful.
+RVRS (Rivers) is a symbolic smart contract language designed for the Cardano blockchain. It treats code not just as logic, but as ritual — something expressive, structured, and meaningful.
 
 This introduction explains the "why" of RVRS before the "how."
 
@@ -8,35 +8,47 @@ This introduction explains the "why" of RVRS before the "how."
 
 ## 🌊 What Is RVRS?
 
-RVRS is a domain-specific language (DSL) for writing smart contracts in a symbolic, ritualistic style. Every contract is a flow: deliberate, readable, and expressive. It emphasizes clarity over cleverness and intention over terseness.
+RVRS is a domain-specific language (DSL) for writing smart contracts in a symbolic, ritualistic style. Every contract is a flow: deliberate, readable, and expressive. It emphasizes clarity over cleverness, and intention over terseness.
 
-RVRS compiles into [Aiken](https://aiken-lang.org), a Cardano smart contract language. This allows symbolic RVRS contracts to execute safely on-chain.
+RVRS compiles into [Aiken](https://aiken-lang.org), a Cardano-native smart contract language. This allows expressive RVRS contracts to be executed safely on-chain.
 
 ---
 
 ## ✨ Why Symbolic?
 
-Traditional languages focus on low-level precision. RVRS embraces symbolic constructs that:
+Most programming languages are built for machines first and humans second. RVRS reverses this.
+
+It embraces symbolic constructs that:
 
 - Reflect intent directly (`delta` for change, `branch` for decision)
 - Encourage poetic expression in logic
-- Help developers write with clarity, rhythm, and flow
+- Help developers write with rhythm, resonance, and clarity
 
-It's a language where the *meaning* of code is as important as its execution.
+It’s a language where the *meaning* of code matters as much as its behavior.
 
 ---
 
 ## 🔁 Current Capabilities
 
-As of version `v0.8.5`, RVRS supports:
+As of version `v0.9.0`, RVRS includes:
 
-- Full parser for all Core 6 constructs
-- Intermediate Representation (IR) + interpreter
-- Type annotations for variables
-- Flow evaluation with return and trace
-- Early Aiken transpilation examples (see `/examples/transpilation`)
+- ✅ Full parser for all Core 6 constructs
+- ✅ Intermediate Representation (IR) and interpreter
+- ✅ Static typechecking for expressions and flows
+- ✅ Type annotations for variables
+- ✅ Flow evaluation with return, trace, and control
+- ✅ Ya-based recursive AST structure
+- ✅ A growing test suite with golden + regression support
 
-Upcoming milestones include static type checking, codegen, and developer tooling.
+Upcoming milestones include improved REPL support, contract-mode flow targeting, and WebAssembly compilation.
+
+---
+
+## 🧘 Ritual Syntax & Style
+
+RVRS code is meant to be read aloud — like invocation.
+
+To maintain expressive clarity and consistency, we offer a full [Style Guide](./08_styleguide.md) covering idioms, formatting, and design tone.
 
 ---
 
@@ -49,8 +61,10 @@ To understand RVRS in depth, follow this order:
 3. **[Syntax](./03_syntax.md)** – Understand the Core 6 and expression rules  
 4. **[Testing](./04_testing.md)** – Learn how we verify RVRS behavior  
 5. **[Module Map](./05_module-map.md)** – Explore the codebase structure  
-6. **[Developer Log](./06_dev-log.md)** – View progress and recent changes
+6. **[Developer Log](./06_dev-log.md)** – View progress and recent changes  
+7. **[Style Guide](./08_styleguide.md)** – Learn how to write idiomatic RVRS
 
 ---
 
-RVRS is still forming. Still flowing. But it invites you to build something meaningful—ritual by ritual, line by line.
+RVRS is still forming. Still flowing.  
+But it invites you to build something meaningful — ritual by ritual, line by line.

--- a/docs/01_Prelude_of_Rituals.md
+++ b/docs/01_Prelude_of_Rituals.md
@@ -4,6 +4,8 @@ Welcome to the **Prelude of Rituals**, the standard library of flows for the RVR
 
 They are written in pure RVRS, lowered to IR, and merged into the evaluation environment. This allows user flows to call them as if they were native constructs.
 
+As of v0.9.0, these rituals are typechecked and executed in the same environment as user-defined flows.
+
 ---
 
 ## 🌊 Core Ritual Flows
@@ -56,9 +58,15 @@ RVRS embraces a symbolic naming convention. Many flows use poetic or metaphorica
 
 > ✨ These rituals are more than tools—they are **symbols**.
 
+- They are also idioms. Examples of how to write expressive, idiomatic RVRS.
+
+- See the [Style Guide](08_styleguide.md) for more on tone and structure.
+
 ---
 
 ## 🧪 Usage Example
+
+These flows are directly invocable in any user-defined RVRS program:
 
 ```rvrs
 flow main {
@@ -81,14 +89,20 @@ flow main {
 - Loaded via parser and lowered to IR using `lowerFlow`
 - Merged into the global `FlowEnv` during evaluation
 - Flows defined here are testable via `RunIRTests`
+- Flows defined here are validated by both the typechecker and evaluator.
+- They are tested via `RunIRTests`, and merged automatically when `evalIRFlow` runs.
 
 ---
 
 ## 🌱 Next Steps
 
-- Expand with additional rituals (e.g., `cleanse`, `align`, `multiply`, `greater_than`)
+- Expand with additional rituals (e.g., `cleanse`, `align`, `multiply`, `greater_than`, `echo_if`)
 - Begin annotating types for stricter validation
 - Add control structures, utility flows, and symbolic patterns for contracts
+
+
+🌟 Want to contribute a new ritual? See [07_contributions.md](07_contributions.md) and submit a symbolic flow.
+
 
 ---
 

--- a/docs/02_roadmap.md
+++ b/docs/02_roadmap.md
@@ -4,61 +4,66 @@ This document outlines the development roadmap for RVRS, a symbolic smart contra
 
 RVRS is evolving through versioned releases toward a stable, expressive, and secure contract-writing experience. This roadmap captures current progress, upcoming features, and long-term goals.
 
+_Updated for version `v0.9.0`_
+
 ---
 
 ## ✅ Core Milestones (Completed)
 
-| Version | Feature | Status |
-|---------|---------|--------|
-| `v0.1`–`v0.6` | Parser + Core 6 constructs (`flow`, `delta`, `branch`, etc.) | ✅ Complete  
-| `v0.7` | Intermediate Representation (IR) + evaluation layer | ✅ Complete  
-| `v0.8` | Type annotations + scoped variable enforcement | ✅ In Progress  
-| `v0.8.5` | Aiken target rationale + hand-written transpilation examples | ✅ Done
+| Version     | Feature                                                | Status      |
+|-------------|--------------------------------------------------------|-------------|
+| `v0.1`–`v0.6` | Parser + Core 6 constructs (`flow`, `delta`, `branch`, etc.) | ✅ Complete |
+| `v0.7`       | Intermediate Representation (IR) + evaluation layer   | ✅ Complete |
+| `v0.8`       | Type annotations + scoped variable enforcement        | ✅ Complete |
+| `v0.8.5`     | Aiken target rationale + hand-written transpilation examples | ✅ Done     |
+| `v0.9.0`     | Static typechecking + Ya integration + style guide    | ✅ Complete |
 
 ---
 
 ## 🔜 Near-Term Goals
 
-| Target | Feature | Notes |
-|--------|---------|-------|
-| `v0.9` | Type enforcement for all expressions (static checks) | Enables codegen  
-| `v1.0` | First working code generation pass → Aiken | MVP contract output  
-| `v1.1` | Refined error messages + REPL mode | Developer feedback tools  
-| `v1.2` | Project scaffolding + CLI utilities | `rvrs new`, `rvrs fmt`, `rvrs run`  
+| Target  | Feature                                     | Notes                     |
+|---------|---------------------------------------------|---------------------------|
+| `v1.0`  | First working code generation pass → Aiken  | MVP contract output       |
+| `v1.1`  | Refined error messages + REPL mode          | Developer feedback tools  |
+| `v1.2`  | Project scaffolding + CLI utilities         | `rvrs new`, `rvrs fmt`, `rvrs run` |
 
 ---
 
 ## 🌱 Future Language Features
 
-| Category | Feature | Description |
-|----------|---------|-------------|
-| Typing | Nominal Type System | Default: Types are declared by name  
-| Typing | Refinement Types | Enforce conditions on data (e.g., "only if > 0")  
-| Typing | Indexed Types | State-aware types (e.g., “only callable after deposit”)  
-| Control Flow | Pattern Matching | Symbolic deconstruction inside `branch` or `flow`  
-| Modularity | Imports & Modules | Import other `.rvrs` flows and stdlib  
-| Contracts | Entry Points & Params | On-chain execution constraints and validators  
-| Codegen | Plutus Core Backend | Direct-to-core alternative target  
-| Codegen | JSON/Metadata Emit | For off-chain metadata and Midnight DX use  
+| Category     | Feature              | Description                                       |
+|--------------|----------------------|---------------------------------------------------|
+| Typing       | Nominal Type System  | Default: Types are declared by name              |
+| Typing       | Refinement Types     | Enforce conditions on data (e.g., "only if > 0") |
+| Typing       | Indexed Types        | State-aware types (e.g., “only callable after deposit”) |
+| Control Flow | Pattern Matching     | Symbolic deconstruction inside `branch` or `flow`|
+| Modularity   | Imports & Modules    | Import other `.rvrs` flows and stdlib            |
+| Contracts    | Entry Points & Params| On-chain execution constraints and validators     |
+| Codegen      | Plutus Core Backend  | Direct-to-core alternative target                |
+| Codegen      | JSON/Metadata Emit   | For off-chain metadata and Midnight DX use       |
 
 ---
 
 ## 🌀 Philosophy Goals
 
-RVRS isn't just a programming language—it’s a ritualistic and symbolic framework. The roadmap also includes:
-- ✍️ Developing `guide`/`muse` spirit layer (AI co-writing interface)
-- 📖 Writing the `Founding Fibers` document (language principles + governance)
-- 🪞 Visual syntax explorer (AST tree growth or ritual map)
+RVRS isn’t just a programming language — it’s a ritualistic and symbolic framework. These goals continue to shape its identity:
+
+- ✍️ Develop a `guide`/`muse` **Spirit Layer** — a conversational AI co-authoring interface
+- 📖 Finalize the `Founding Fibers` — RVRS’s guiding philosophy and governance model
+- 🪞 Create a **visual syntax explorer** — a ritual map or AST tree grown from flows
+- 📘 Maintain the [Style Guide](08_styleguide.md) — to codify RVRS idioms and tone
 
 ---
 
 ## 🧭 Long-Term Vision
 
-- Write symbolic smart contracts in a poetic form
-- Transpile them to production-grade Aiken or Plutus Core
+- Write symbolic smart contracts in a poetic, expressive form
+- Transpile to production-grade Aiken or Plutus Core
 - Foster a new aesthetic and mental model for contract authorship
-- Create tools for education, onboarding, and community rituals
+- Build tools for onboarding, ritual learning, and creative dev expression
 
 ---
 
-For current progress, see [`README.md`](../README.md) or browse the [`examples/`](../examples/) directory.
+For current progress, see [`README.md`](../README.md)  
+Or explore examples in the [`examples/`](../examples/) directory.

--- a/docs/03_syntax.md
+++ b/docs/03_syntax.md
@@ -1,26 +1,22 @@
 # 📜 RVRS Syntax Reference
 
-> "Not all contracts are code. Some are rivers."
+*"Not all contracts are code. Some are rivers."*
 
-This is the living syntax document for **RVRS** — a ceremonial, expressive language for writing smart contracts on Cardano. It outlines the current capabilities (as of `v0.8.0-dev`) and previews functionality expected in the `v1.0` launch.
-
----
+This is the living syntax document for **RVRS**, a ceremonial, expressive language for writing smart contracts on Cardano. It outlines the current capabilities (as of `v0.9.0`) and previews functionality expected in the `v1.0` launch.
 
 ## 🌿 Core Rituals (Executable Essentials)
 
 These are the minimum required to write working flows (functions) in RVRS:
 
-| Keyword   | Meaning                             | Aiken Equivalent |
-|-----------|--------------------------------------|------------------|
-| `flow`    | Function definition / ritual         | `fn`             |
-| `delta`   | Define or mutate a scoped variable   | `let` / rebind   |
-| `source`  | Top-level constant definition        | `let` (const)    |
-| `echo`    | Return a value from a flow           | `return`         |
-| `mouth`   | Emit/log a value without halting     | `trace`          |
-| `branch`  | Conditional block                    | `if` / `else`    |
-| `return`  | (Alternative to `echo`, optional)    | `return`         |
-
----
+| Keyword  | Meaning                           | Aiken Equivalent |
+|----------|-----------------------------------|------------------|
+| `flow`   | Function definition / ritual      | `fn`             |
+| `delta`  | Define or mutate a scoped variable| `let` / rebind   |
+| `source` | Top-level constant definition     | `let` (const)    |
+| `echo`   | Return a value from a flow        | `return`         |
+| `mouth`  | Emit/log a value without halting  | `trace`          |
+| `branch` | Conditional block                 | `if` / `else`    |
+| `return` | (Alternative to `echo`, optional) | `return`         |
 
 ## 🧠 Type System (Enforced Constructs)
 
@@ -34,83 +30,73 @@ flow identity(n: Num): Num {
 ```
 
 Supported base types:
-- `Num`
-- `Bool`
-- `Str` *(planned for v1.0)*
-- `List[T]` *(planned)*
-
----
+* `Num`
+* `Bool`
+* `Str` *(enabled, expanding in v1.0)*
+* `List[T]` *(planned)*
 
 ## 📦 Flow Composition (Calls & Modularity)
 
-| Keyword   | Meaning                          | Role in Execution     |
-|-----------|----------------------------------|------------------------|
-| `call`    | Invoke another flow              | Function call          |
-| `return`  | Exit with a value                | Return from flow       |
-| `assert`  | Require truth or halt            | Assertion guard        |
-| `import`  | Bring in external `.rvrs` flows  | Module inclusion (v1)  |
-| `@onchain`, `@mint`, `@view` | Flow attributes | Contract modes (planned) |
-
----
+| Keyword                           | Meaning                        | Role in Execution        |
+|-----------------------------------|--------------------------------|--------------------------|
+| `call`                           | Invoke another flow            | Function call            |
+| `return`                         | Exit with a value              | Return from flow         |
+| `assert`                         | Require truth or halt          | Assertion guard          |
+| `import`                         | Bring in external `.rvrs` flows| Module inclusion (v1)    |
+| `@onchain`, `@mint`, `@view`     | Flow attributes                | Contract modes (planned) |
 
 ## 🕊️ Symbolic & Expressive Keywords *(Experimental / Future)*
 
 These are poetic or expressive tools that may evolve post-v1:
 
-| Keyword     | Meaning                             | Mapping / Status     |
-|-------------|--------------------------------------|-----------------------|
-| `veil`      | Optional or hidden logic             | `Maybe` / planned     |
-| `tide`      | Iterate over a sequence              | `for` / planned       |
-| `stream`    | Represents a flowing list            | `List` / placeholder  |
-| `chant`     | Symbolic transformation              | Expr macro?     |
-| `glyph`     | User-defined symbolic type           | `type` / long-term    |
-| `ritual`    | Named reusable block/module          | Planned               |
-
----
+| Keyword  | Meaning                      | Mapping / Status     |
+|----------|------------------------------|----------------------|
+| `veil`   | Optional or hidden logic     | `Maybe` / planned    |
+| `tide`   | Iterate over a sequence      | `for` / planned      |
+| `stream` | Represents a flowing list    | `List` / placeholder |
+| `chant`  | Symbolic transformation      | Expr macro?          |
+| `glyph`  | User-defined symbolic type   | `type` / long-term   |
+| `ritual` | Named reusable block/module  | Planned              |
 
 ## 🪨 Structural & Meta Keywords
 
 Used for constants, annotation, or symbolic structure.
 
-| Keyword     | Meaning                              | Notes                  |
-|-------------|---------------------------------------|------------------------|
-| `pillar`    | Immutable constant                   | `const`                |
-| `mark`      | Annotation or tag                    | Could support metadata |
-| `drift`     | Halt flow early / fail               | `fail` / `error`       |
-| `mouthpiece`| Conditional trace                    | Planned                |
-| `echo_if`   | Conditional return                   | Internal sugar         |
-
----
+| Keyword      | Meaning                    | Notes                    |
+|--------------|----------------------------|--------------------------|
+| `pillar`     | Immutable constant         | `const`                  |
+| `mark`       | Annotation or tag          | Could support metadata   |
+| `drift`      | Halt flow early / fail     | `fail` / `error`         |
+| `mouthpiece` | Conditional trace          | Planned                  |
+| `echo_if`    | Conditional return         | Internal sugar           |
 
 ## 🧪 Syntax & Style Notes
 
 ### 🎨 Visual Identity *(Design Layer — Optional)*
-
-- **Syntax Themes:** River-blue for flows, moss-green for branches, ink-black for deltas
-- **Poetic Formatting:** Flows should be readable like ritual text or spells — indented with space to breathe
-- **CLI Aesthetic:** Terminal colors based on type or keyword class (e.g. `delta` = blue, `echo` = white)
+* **Syntax Themes:** River-blue for flows, moss-green for branches, ink-black for deltas
+* **Poetic Formatting:** Flows should be readable like ritual text or spells — indented with space to breathe
+* **CLI Aesthetic:** Terminal colors based on type or keyword class (e.g. `delta` = blue, `echo` = white)
 
 ### 🔖 Annotations & Contracts
-
-- Planned decorator-style flags for `@onchain`, `@mint`, `@test`, `@view`
-- Could extend into validator-type generation or behavior-based compilation paths
+* Decorator-style flags like `@onchain`, `@mint`, `@test`, and `@view` are planned
+* Future extensions may enable validator-type generation and compilation path control
 
 ### 📘 Icons/Glyphs (Docs Only)
+* Use symbolic icons sparingly to emphasize ritual depth
+* Example: `🌊` = `flow`, `🪨` = `pillar`, `🔀` = `branch` (for documentation only)
 
-- Use symbolic icons sparingly (no emojis) to represent conceptually heavy constructs
-- Example: `🌊` = `flow`, `🪨` = `pillar`, `🔀` = `branch` — docs only
+## ✅ Current Status:
+
+RVRS v0.9.0 supports:
+* Full `flow` and variable definition syntax
+* Type annotations and type enforcement for expressions
+* IR evaluation and test infrastructure
+* Standard library merging at runtime
+* Early integration with `Ya`'s recursive data structures
+* Aiken transpilation examples for real-world mapping
 
 ---
 
-### ✅ Current Status:  
-RVRS v0.8.0-dev supports:
-- Full `flow` and variable definition syntax
-- Type annotations and basic enforcement
-- IR evaluation and test infrastructure
-- Standard library merging at runtime
+*"RVRS is not just a language. It's a current. Designed to carry intent with clarity, weight, and meaning."*
 
----
-
-> "RVRS is not just a language. It's a current — designed to carry intent with clarity, weight, and meaning."
-
-**Last Updated: 2025-05-22**
+**Last Updated: 2025-06-11**

--- a/docs/04_testing.md
+++ b/docs/04_testing.md
@@ -2,23 +2,19 @@
 
 Welcome to the test suite for RVRS — the Ritual Virtual River System. This guide outlines how tests are structured, where to find them, and how to run them.
 
----
-
-## 📁 Folder Structure
+## Folder Structure
 
 All test files live under the `examples/` directory and are grouped by intent:
 
-| Folder         | Purpose                                                  |
-|----------------|----------------------------------------------------------|
-| `core/`        | Fundamental language features (math, scope, delta, etc.) |
-| `edge_cases/`  | Unexpected, invalid, or boundary-case behaviors           |
-| `flows/`       | Flow invocation, arguments, return logic                  |
-| `poetic/`      | Symbolic, expressive, or aesthetic RVRS patterns          |
-| `regression/`  | Full integration and coverage tests (`full_test.rvrs`)    |
+| Folder        | Purpose                                                      |
+|---------------|--------------------------------------------------------------|
+| `core/`       | Fundamental language features (math, scope, delta, etc.)    |
+| `edge_cases/` | Unexpected, invalid, or boundary-case behaviors             |
+| `flows/`      | Flow invocation, arguments, return logic                    |
+| `poetic/`     | Symbolic, expressive, or aesthetic RVRS patterns            |
+| `regression/` | Full integration and coverage tests (`full_test.rvrs`)      |
 
----
-
-## ▶️ Running Tests
+## Running Tests
 
 To run a single test file:
 
@@ -38,20 +34,24 @@ To run IR-level evaluations (internal flow logic):
 cabal run RunIRTests
 ```
 
----
+To run type system tests (expression-level typechecking):
 
-## 🧪 Test Format
+```bash
+cabal run TestTypeCheck
+```
+
+
+## Test Format
 
 Each `.rvrs` file is a complete script and must contain a `flow main()` declaration.
 
 RVRS will automatically evaluate the `main` flow in each test.
 
 Expected forms of output and diagnostics:
-
-- `echo` → returns a value and halts flow
-- `mouth` → prints/logs a value (non-halting)
-- `assert` → enforces truth, halts on failure
-- `-- expect-fail` → marks a test expected to fail (e.g., type error)
+* `echo` → returns a value and halts flow
+* `mouth` → prints/logs a value (non-halting)
+* `assert` → enforces truth, halts on failure
+* `-- expect-fail` → marks a test expected to fail (e.g., type error)
 
 Example:
 
@@ -63,27 +63,25 @@ flow main(): Num {
 }
 ```
 
----
+## Failure Reporting
 
-## ⚠️ Failure Reporting
+* Type mismatches, undefined names, and assertion failures produce error messages
+* Expected failures are tracked by `RunAll.hs` and `RunIRTests.hs`
+* If a file marked `-- expect-fail` passes, the test fails intentionally
+* If a file not marked `-- expect-fail` fails, the test fails genuinely
+* Files can include notes like `-- expect: 42` to document expected values (planned)
 
-- Type mismatches, undefined names, and assertion failures produce error messages
-- Expected failures are tracked by `RunAll.hs` and `RunIRTests.hs`
-- If a file marked `-- expect-fail` passes, the test fails intentionally
-- If a file not marked `-- expect-fail` fails, the test fails genuinely
+## Best Practices
 
----
-
-## ✅ Best Practices
-
-- Group tests logically and name descriptively
-- Use `assert` to verify correctness
-- Always include a `main` flow
-- Prefer `echo` or `mouth` for clarity
-- Mark failing tests explicitly with `-- expect-fail`
+* Group tests logically and name descriptively
+* Use `assert` to verify correctness
+* Always include a `main` flow
+* Prefer `echo` or `mouth` for clarity
+* Mark failing tests explicitly with `-- expect-fail`
+* Use the `regression/` folder for canonical feature sets
 
 ---
 
-> "Tests in RVRS aren’t just checks. They’re affirmations — that each branch splits, each echo returns, and each flow holds."
+*"Tests in RVRS aren't just checks. They're affirmations — that each branch splits, each echo returns, and each flow holds."*
 
-**Last Updated: 2025-05-22**
+**Last Updated: 2025-06-11**

--- a/docs/05_module-map.md
+++ b/docs/05_module-map.md
@@ -1,51 +1,58 @@
 # 🌊 RVRS Module Map
 
-This document outlines the core modules of RVRS and their responsibilities. Use this map to understand how code flows through the system.
+This document outlines the core modules of **RVRS** and their responsibilities.  
+Use this map to understand how code flows through the system.
 
 ---
 
 ## 📦 Core Modules
 
-| Module | File | Purpose |
-|--------|------|---------|
-| `RVRS.Parser` | `src/RVRS/Parser/` | Parses RVRS source into AST form. Submodules handle expressions, statements, types, and imports. |
-| `RVRS.AST` | `src/RVRS/AST.hs` | Defines the high-level abstract syntax tree used by the parser. |
-| `RVRS.Lower` | `src/RVRS/Lower.hs` | Converts AST to IR (intermediate representation). |
-| `RVRS.IR` | `src/RVRS/IR.hs` | Defines intermediate representation used for evaluation and type checking. |
-| `RVRS.TypeCheck` | `src/RVRS/TypeCheck.hs` | Performs static analysis and ensures type correctness of IR. |
-| `RVRS.Env` | `src/RVRS/Env.hs` | Runtime environment definitions and variable bindings. |
-| `RVRS.Value` | `src/RVRS/Value.hs` | Core runtime value definitions (`VStr`, `VNum`, etc). |
-| `RVRS.Eval.*` | `src/RVRS/Eval/` | Evaluation of IR constructs. Split into `Expr`, `Stmt`, and `Flow` evaluators. |
-| `RVRS.Codegen` | `src/RVRS/Codegen.hs` | (Scaffolded) Future code generation target (e.g., Aiken). |
-| `RVRS.Pretty` | `src/RVRS/Pretty.hs` | Pretty-printing for diagnostics or output. |
+| Module             | File                      | Purpose |
+|--------------------|---------------------------|---------|
+| `RVRS.Parser`      | `src/RVRS/Parser/`        | Parses RVRS source into AST form. Submodules handle expressions, statements, types, and imports. |
+| `RVRS.AST`         | `src/RVRS/AST.hs`         | Defines the high-level abstract syntax tree used by the parser. |
+| `RVRS.Lower`       | `src/RVRS/Lower.hs`       | Converts AST to IR (intermediate representation). |
+| `RVRS.IR`          | `src/RVRS/IR.hs`          | Defines intermediate representation used for evaluation and type checking. |
+| `RVRS.Typecheck.*` | `src/RVRS/Typecheck/`     | Static type system logic, including `Check`, `Types`, and helpers. |
+| `RVRS.Env`         | `src/RVRS/Env.hs`         | Runtime environment definitions and variable bindings. |
+| `RVRS.Value`       | `src/RVRS/Value.hs`       | Runtime value definitions (`VStr`, `VNum`, etc). |
+| `RVRS.Eval.*`      | `src/RVRS/Eval/`          | IR evaluation logic. Split into `Expr`, `Stmt`, and `Flow`. |
+| `RVRS.Codegen`     | `src/RVRS/Codegen.hs`     | (Planned) Code generation target (e.g., Aiken). |
+| `RVRS.Pretty`      | `src/RVRS/Pretty.hs`      | Pretty-printing for AST, values, and diagnostics. |
+| `Ya.Recursive`     | `lib/Ya/Recursive.hs`     | Integrated support for recursive types via `Ya`. |
 
 ---
 
 ## 🧪 Testing Modules
 
-| Module | File(s) | Purpose |
-|--------|---------|---------|
-| `Main.hs` | `app/Main.hs` | Entry point (placeholder or REPL, if enabled). |
-| `RunAll.hs` | `app/RunAll.hs` | Runs the full test suite. |
-| `RunIRTests.hs` | `app/RunIRTests.hs` | Runs IR-focused tests. |
-| `TestLower.hs` | `app/TestLower.hs` | (Optional) Verifies lowering correctness. |
+| Module             | File(s)                  | Purpose |
+|--------------------|--------------------------|---------|
+| `Main.hs`          | `app/Main.hs`            | Entry point (future REPL or CLI tool). |
+| `RunAll.hs`        | `app/RunAll.hs`          | Runs the full test suite. |
+| `RunIRTests.hs`    | `app/RunIRTests.hs`      | Evaluates IR-level logic. |
+| `TestLower.hs`     | `app/TestLower.hs`       | Verifies correctness of AST → IR lowering. |
+| `TestTypeCheck.hs` | `app/TestTypeCheck.hs`   | Unit tests for expression-level type inference. |
 
 ---
 
 ## 🧱 Stdlib and Rituals
 
-| File | Purpose |
-|------|---------|
-| `stdlib/stdlib.rvrs` | Core prelude flows (standard rituals). |
-| `docs/Prelude_of_Rituals.md` | Documentation of the stdlib symbols. |
+| File                     | Purpose |
+|--------------------------|---------|
+| `stdlib/stdlib.rvrs`     | Core prelude flows (standard rituals). |
+| `docs/Prelude_of_Rituals.md` | Documentation for the standard library. |
 
 ---
 
 ## 📁 Directory Layout Summary
 
-- `src/`: Source code
-- `tests/`: Test files grouped by purpose
-- `docs/`: Project documentation
-- `examples/`: Showcase or learning flows
-- `app/`: Executables and test runners
+- `src/` – Source code for the language
+- `lib/` – External integrations (e.g., `Ya`)
+- `app/` – Entry points and test runners
+- `examples/` – Flow scripts and test cases
+- `docs/` – Documentation and reference
+- `stdlib/` – Built-in RVRS flows and rituals
 
+---
+
+> “The modules of RVRS reflect the same structure as its syntax: a layered current — flowing from ritual to result.”

--- a/docs/06_dev-log.md
+++ b/docs/06_dev-log.md
@@ -1,6 +1,59 @@
 # RVRS Developer Log
 ---
 
+## 🗓️ 2025-06-11 — Type Enforcement Expands (v0.9.0-dev in Progress)
+
+### ✅ Summary  
+- Extended type enforcement with:
+  - Expression-level type inference for binary ops (`+`, `-`, `*`, `/`, `==`, etc.)
+  - Support for `Recursive` wrapping using `Ya` integration
+- Added new type-checking runner: `TestTypeCheck.hs`
+  - Covers direct expression tests for `typeOfExpr`
+- Confirmed runtime handling of:
+  - Type mismatches
+  - Unbound variables
+  - Assertion failures
+- Tests now fully span: source, IR, and expression-level checks
+
+📊 Test Totals:
+- ✅ Passed: 39
+- ⚠️ Expected Failures: 5
+- ❌ Unexpected Failures: 0
+- 🧪 Total Tests: 45
+
+📂 Coverage:
+- `RunAll`: 33 tests (core + poetic + edge)
+- `RunIRTests`: 5 tests (IR-level behavior)
+- `TestTypeCheck`: 11 unit tests
+
+### 🧠 Key Features Progressing Toward v1.0
+- ✅ Binary op type enforcement via `typeOfExpr`
+- ✅ Type environment tracking using `TypeEnv`
+- ✅ Expression error reporting with `TypeMismatch`
+- 🚧 Flow-level return type validation
+- 🚧 Branch condition type enforcement (`Bool` only)
+- 🚧 Flow argument arity/type checking
+
+### 🧭 What’s Next
+- [ ] Validate all `branch` condition types to ensure `Bool`
+- [ ] Enforce return type alignment in flow declarations
+- [ ] Add multi-arg flow tests with arity mismatches
+- [ ] Improve `TypeMismatch` and `ReturnMismatch` messages
+- [ ] Consider stricter `source` validation (no rebinds)
+
+### 🧹 Repo State
+- Branch: `type-enforce-dev`  
+- Mainline: stable at `v0.8.7`  
+- New files:
+  - `TestTypeCheck.hs` (expression-level test runner)
+- Modified:
+  - `RVRS/Typecheck/Check.hs` for binary op logic
+  - `Ya` integrated for recursion unwrapping
+
+> *“As the river widens, so does its depth. The types are now part of the current.”*
+
+---
+
 ## 🗓️ 2025-05-22 — Type Enforcement Begins (v0.8.0-dev in Progress)
 
 ### ✅ Summary  

--- a/docs/07_contributions.md
+++ b/docs/07_contributions.md
@@ -19,7 +19,7 @@ _See `docs/module-map.md` and `tests/README.md` for details._
 
 ---
 
-##  How to Contribute
+## How to Contribute
 
 ### 1. Set Up the Project
 
@@ -56,9 +56,11 @@ All behavioral changes should include or update one or more test cases.
 ```bash
 cabal run RunAll
 cabal run rvrs tests/path/to/test.rvrs
+cabal run RunIRTests
+cabal run TestTypeCheck
 ```
 
-> ** Testing Policy for Contributors**
+> **Testing Policy for Contributors**  
 >
 > All behavioral changes should include or update one or more tests.  
 > This includes:
@@ -131,5 +133,3 @@ When reporting a bug or proposing a feature, please include:
 - Use descriptive names and comments  
 - Small, self-contained PRs are preferred  
 - Respect the balance of symbolism and structure in RVRS  
-
----

--- a/docs/08_styleguide.md
+++ b/docs/08_styleguide.md
@@ -1,0 +1,105 @@
+# RVRS Style Guide
+
+## 1. Code Formatting
+
+### 1.1 Indentation & Layout
+- Use 2-space indentation.
+- Separate logical blocks with vertical spacing.
+- Prefer line breaks for `case`, `do`, and `let` blocks when nested.
+
+### 1.2 Imports
+- Group imports: standard library first, then internal modules, then qualified imports.
+- Example:
+  ```haskell
+  import Data.Map (Map)
+  import qualified Data.Map as Map
+  import RVRS.AST
+  import Ya (Recursive(..), unwrap)
+  ```
+
+### 1.3 Language Extensions
+- Declare extensions per module.
+- Commonly used: `PatternSynonyms`, `StandaloneDeriving`, `UndecidableInstances`.
+
+---
+
+## 2. Naming Conventions
+
+### 2.1 Modules
+- Use `CamelCase`, namespaced under `RVRS.*`.
+
+### 2.2 Types & Constructors
+- Prefix concrete types with `T`: `TNum`, `TBool`.
+- Use descriptive names: `FlowIR`, `EvalIR`, `EvalError`.
+
+### 2.3 Functions
+- Prefer short but descriptive names: `evalExpr`, `typeOfExpr`, `add`, `notExpr`.
+- Use `expr` and `stmt` as common suffixes for handlers.
+
+---
+
+## 3. Expression & Evaluation Idioms
+
+### 3.1 Pattern Matching with Recursive
+- Always pattern match via `unwrap expr`.
+- Avoid deeply nested expressions by breaking into smaller helpers.
+
+### 3.2 Eval and Typecheck Structure
+- Use monads for expression evaluation.
+- Type errors are specific and custom: `TypeMismatch`, `UnknownVariable`, `UnsupportedOp`.
+
+### 3.3 Binary Operations
+- Use `checkBinary` and `binOp` helpers for consistency.
+
+### 3.4 Error Handling
+- Favor `throwError` over `fail` or `error` in monadic contexts.
+- Avoid catching general exceptions; prefer typed control (`ReturnValue`, `RuntimeError`).
+
+---
+
+## 4. Testing Philosophy
+
+### 4.1 Unit Tests
+- Use `Test.HUnit` for typechecking logic.
+- Prefer pattern coverage over random cases.
+
+### 4.2 Integration & Regression
+- Use `RunAll.hs` to scan, run, and summarize `.rvrs` files.
+- Expected failures: detect via `-- expect-fail` comment.
+
+### 4.3 Output Style
+- Keep tests colorful, labeled, and expressive.
+
+---
+
+# Appendix A: RVRS Idioms
+
+- **Recursive Wrapper**: Always use `Recursive` to wrap AST nodes.
+- **Echo, Mouth, Whisper**: Reflective naming evokes a ritual tone. Do not replace with generic terms.
+- **Delta vs Source**: `Source` is immutable (once set), `Delta` is mutable. Keep this metaphor consistent.
+
+**Example:**
+```haskell
+Delta "x" Nothing (Recursive (NumLit 42))
+Mouth (Recursive (Var "x"))
+```
+
+---
+
+# Appendix B: Design Philosophy & Tone
+
+- RVRS is not just a language — it is a **ritual system** for logic.
+- It favors readability, expressiveness, and symbolic meaning.
+- Output is part of the language’s *aesthetic contract*. It should feel alive and intentional.
+
+### Naming Tone
+- Prefer names that suggest meaning, action, or transformation: `Flow`, `Echo`, `Mouth`, `Branch`, `Delta`.
+
+### Code as Ritual
+- A flow defines intent.
+
+- A statement expresses it.
+
+- RVRS is written to resonate: read aloud, rendered with clarity, and shaped to feel alive.
+
+

--- a/src/Ya/README.md
+++ b/src/Ya/README.md
@@ -1,0 +1,39 @@
+# Ya (Я) — Recursive Expression Framework
+
+**Ya** is an experimental module integrated into RVRS to support generalized recursive data structures and enable expressive evaluation and transformation of symbolic flows.
+
+---
+
+## What is Ya?
+
+Ya (or Я) introduces the idea of **recursive fixpoints** to abstract over self-referential constructs, allowing RVRS to reason about expressions and statements as deeply structured, recursive trees.
+
+It is not a language in the traditional sense but a **conceptual foundation** for visual and symbolic manipulation of flows in RVRS.
+
+---
+
+## What's in this Directory?
+
+| File | Purpose |
+|------|---------|
+| `Conversion.hs` | Helpers to convert between RVRS and Ya-style recursive types |
+| `Instances.hs`  | Typeclass instances for `Recursive` wrappers (e.g., `Eq`, `Show`) |
+
+---
+
+## Why use Ya?
+
+RVRS uses Ya’s fixpoint abstraction to:
+- Simplify the evaluation logic via structured recursion
+- Support symbolic transformations and pretty-printing
+- Enable deeper control over expression trees (e.g., for optimization, visualization)
+
+Ya is a step toward building **interpretable, structural smart contracts**, where form and meaning are as important as execution.
+
+---
+
+## Learn More
+
+- Visit [Ya GitHub](https://github.com/iokasimov/ya) for the original repo
+- Read Murat's writing on recursive languages and natural transformations
+- See how RVRS uses Ya in `RVRS/AST.hs` and `RVRS/Typecheck/Check.hs`


### PR DESCRIPTION
## Docs Overhaul for v0.9

This PR updates and expands RVRS documentation to reflect the current state of the language.

### Included:
- New `Style Guide` (`08_style-guide.md`)
- Updated:
  - Intro (`00_intro.md`)
  - Testing guide (`04_testing.md`)
  - Module map (`05_module-map.md`)
  - Dev log (`06_dev-log.md`) with v0.9 entry
  - Contribution guide (`07_contributions.md`)
- Scaffolded Ya README (`src/Ya/README.md`)

Prepping RVRS for a clean and expressive v0.9 release.
