### PR TITLE
Add negative type checking tests and clean up cabal build

### DIFF
--- a/app/TestTypeCheckNegative.hs
+++ b/app/TestTypeCheckNegative.hs
@@ -1,0 +1,73 @@
+module Main where
+
+import Test.HUnit
+import qualified Data.Map as Map
+
+import RVRS.Typecheck.Check (typeOfExpr)
+import RVRS.Typecheck.Types
+import RVRS.AST
+import Ya (Recursive(..))
+
+-- Simple type environment
+testEnv :: TypeEnv
+testEnv = Map.fromList
+  [ ("x", TNum)
+  , ("y", TBool)
+  , ("msg", TStr)
+  ]
+
+-- Helpers
+num :: Double -> Recursive Expression
+num = Recursive . NumLit
+
+bool :: Bool -> Recursive Expression
+bool = Recursive . BoolLit
+
+str :: String -> Recursive Expression
+str = Recursive . StrLit
+
+var :: String -> Recursive Expression
+var = Recursive . Var
+
+add :: Recursive Expression -> Recursive Expression -> Recursive Expression
+add a b = Recursive (Add a b)
+
+eq :: Recursive Expression -> Recursive Expression -> Recursive Expression
+eq a b = Recursive (Equals a b)
+
+-- Negative test cases (expected to fail)
+testBadAddBoolNum :: Test
+testBadAddBoolNum = TestCase $
+  case typeOfExpr testEnv (add (bool True) (num 1)) of
+    Left _ -> return ()  -- ✅ expected failure
+    Right t -> assertFailure $ "Unexpected success: got " ++ show t
+
+testBadEqNumStr :: Test
+testBadEqNumStr = TestCase $
+  case typeOfExpr testEnv (eq (num 5) (str "five")) of
+    Left _ -> return ()  -- ✅ expected failure
+    Right t -> assertFailure $ "Unexpected success: got " ++ show t
+
+testBadVarUnbound :: Test
+testBadVarUnbound = TestCase $
+  case typeOfExpr testEnv (var "z") of
+    Left _ -> return ()  -- ✅ expected failure
+    Right t -> assertFailure $ "Unexpected success: got " ++ show t
+
+testBadNestedAdd :: Test
+testBadNestedAdd = TestCase $
+  case typeOfExpr testEnv (add (add (bool True) (num 2)) (num 1)) of
+    Left _ -> return ()
+    Right t -> assertFailure $ "Unexpected success: got " ++ show t
+
+-- Main runner
+main :: IO ()
+main = do
+  putStrLn "🔍 Running negative typeOfExpr tests..."
+  _ <- runTestTT $ TestList
+    [ testBadAddBoolNum
+    , testBadEqNumStr
+    , testBadVarUnbound
+    , testBadNestedAdd
+    ]
+  return ()

--- a/rvrs-lang.cabal
+++ b/rvrs-lang.cabal
@@ -3,6 +3,43 @@ name:                rvrs-lang
 version:             0.1.0.0
 build-type:          Simple
 
+-- === Library: rvrs-lang ===
+library
+  exposed-modules:
+      RVRS.AST
+    , RVRS.Typecheck.Check
+    , RVRS.Typecheck.Types
+  other-modules:
+      RVRS.Codegen
+    , RVRS.Parser
+    , RVRS.Parser.ExprParser
+    , RVRS.Parser.StmtParser
+    , RVRS.Parser.Type
+    , RVRS.Eval
+    , RVRS.Pretty
+    , RVRS.Value
+    , RVRS.Lower
+    , RVRS.Env
+    , RVRS.Utils
+    , Ya.Conversion
+    , Ya.Instances
+  hs-source-dirs:      src
+  build-depends:
+      base >=4.14 && <5
+    , containers
+    , ya
+    , megaparsec
+    , text
+    , prettyprinter
+    , parser-combinators
+    , mtl
+  default-language:    Haskell2010
+  default-extensions:
+    StandaloneDeriving
+    LambdaCase
+
+
+
 -- === Executable: rvrs ===
 executable rvrs
   main-is:             Main.hs
@@ -185,3 +222,23 @@ executable TestTypeCheck
   default-extensions:
     LambdaCase
     , StandaloneDeriving
+
+-- === Executable: TestTypeCheckNegative ===
+executable testtypechecknegative
+  main-is:             TestTypeCheckNegative.hs
+  hs-source-dirs:      app, src
+  other-modules:
+      RVRS.AST
+    , RVRS.Parser.Type
+    , RVRS.Typecheck.Check
+    , RVRS.Typecheck.Types
+    , Ya.Instances
+  build-depends:
+      base >=4.14 && <5
+    , containers
+    , HUnit
+    , ya
+    , megaparsec
+  default-language:    Haskell2010
+  default-extensions:
+    StandaloneDeriving


### PR DESCRIPTION
## Add negative typechecking tests and finalize typecheck setup

This PR completes the typecheck test infrastructure by introducing a new executable:
- `testtypechecknegative` — runs tests that are expected to **fail** typechecking via `typeOfExpr`.

### What’s included:
- 4/4 negative test cases passing cleanly
- Full `.cabal` cleanup:
  - All required `other-modules` declared
  - GHC extensions like `StandaloneDeriving` and `LambdaCase` enabled where needed
- Consolidated and exposed core modules through the new library stanza
- Verified successful builds for:
  - `rvrs`
  - `RunAll`
  - `RunIRTests`
  - `TestLower`
  - `TestTypeCheck`
  - `testtypechecknegative`

### Why it matters:
This PR ensures type enforcement is verifiable both positively and negatively, setting the foundation for RVRS 0.9.

