### PR TITLE
Separate primitive types

### DIFF
--- a/app/TestTypeCheck.hs
+++ b/app/TestTypeCheck.hs
@@ -19,13 +19,13 @@ testEnv = Map.fromList
 
 -- Helper to build expressions
 num :: Double -> Recursive Expression
-num = Recursive . NumLit
+num = Recursive . Lit . Double
 
 bool :: Bool -> Recursive Expression
-bool = Recursive . BoolLit
+bool = Recursive . Lit . Bool
 
 str :: String -> Recursive Expression
-str = Recursive . StrLit
+str = Recursive . Lit . String
 
 var :: String -> Recursive Expression
 var = Recursive . Var

--- a/app/TestTypeCheckNegative.hs
+++ b/app/TestTypeCheckNegative.hs
@@ -18,13 +18,13 @@ testEnv = Map.fromList
 
 -- Helpers
 num :: Double -> Recursive Expression
-num = Recursive . NumLit
+num = Recursive . Lit . Double
 
 bool :: Bool -> Recursive Expression
-bool = Recursive . BoolLit
+bool = Recursive . Lit . Bool
 
 str :: String -> Recursive Expression
-str = Recursive . StrLit
+str = Recursive . Lit . String
 
 var :: String -> Recursive Expression
 var = Recursive . Var

--- a/rvrs-lang.cabal
+++ b/rvrs-lang.cabal
@@ -35,8 +35,12 @@ library
     , mtl
   default-language:    Haskell2010
   default-extensions:
+    ScopedTypeVariables
     StandaloneDeriving
+    PatternSynonyms
     LambdaCase
+    TypeApplications
+    TypeOperators
 
 
 
@@ -75,8 +79,11 @@ executable rvrs
   default-language:    Haskell2010
   default-extensions:
     LambdaCase
-    , StandaloneDeriving
-    , PatternSynonyms
+    ScopedTypeVariables
+    StandaloneDeriving
+    PatternSynonyms
+    TypeApplications
+    TypeOperators
 
 -- === Executable: RunAll ===
 executable RunAll
@@ -116,7 +123,11 @@ executable RunAll
   default-language:    Haskell2010
   default-extensions:
     LambdaCase
-    , StandaloneDeriving
+    ScopedTypeVariables
+    StandaloneDeriving
+    PatternSynonyms
+    TypeApplications
+    TypeOperators
 
 -- === Executable: TestLower ===
 executable TestLower
@@ -153,7 +164,11 @@ executable TestLower
   default-language:    Haskell2010
   default-extensions:
     LambdaCase
-    , StandaloneDeriving
+    ScopedTypeVariables
+    StandaloneDeriving
+    PatternSynonyms
+    TypeApplications
+    TypeOperators
 
 -- === Executable: RunIRTests ===
 executable RunIRTests
@@ -193,7 +208,11 @@ executable RunIRTests
   default-language:    Haskell2010
   default-extensions:
     LambdaCase
-    , StandaloneDeriving
+    ScopedTypeVariables
+    StandaloneDeriving
+    PatternSynonyms
+    TypeApplications
+    TypeOperators
 
 -- === Executable: TestTypeCheck ===
 executable TestTypeCheck
@@ -221,7 +240,11 @@ executable TestTypeCheck
   default-language:    Haskell2010
   default-extensions:
     LambdaCase
-    , StandaloneDeriving
+    ScopedTypeVariables
+    StandaloneDeriving
+    PatternSynonyms
+    TypeApplications
+    TypeOperators
 
 -- === Executable: TestTypeCheckNegative ===
 executable testtypechecknegative
@@ -241,4 +264,8 @@ executable testtypechecknegative
     , megaparsec
   default-language:    Haskell2010
   default-extensions:
+    ScopedTypeVariables
     StandaloneDeriving
+    PatternSynonyms
+    TypeApplications
+    TypeOperators

--- a/src/RVRS/AST.hs
+++ b/src/RVRS/AST.hs
@@ -31,7 +31,6 @@ data Statement e
   | Return (Recursive Expression)
   | Call String [Recursive Expression]
   | Assert (Recursive Expression)
-
   deriving (Show, Eq)
 
 data Expression e

--- a/src/RVRS/AST.hs
+++ b/src/RVRS/AST.hs
@@ -1,6 +1,6 @@
 module RVRS.AST where
 
-import Ya (Recursive (..))
+import Ya (S, Object (This, That), Recursive (..))
 
 import RVRS.Parser.Type (RVRSType(..))
 import Ya.Instances ()
@@ -36,8 +36,7 @@ data Statement e
 
 data Expression e
   = Var String
-  | StrLit String
-  | BoolLit Bool
+  | Lit Primitive
   | Equals e e
   | GreaterThan e e
   | LessThan e e
@@ -45,13 +44,18 @@ data Expression e
   | Sub e e
   | Mul e e
   | Div e e
-  | NumLit Double
   | Not e
   | And e e
   | Or e e
   | CallExpr String [e]
   | Neg e
   deriving (Show, Eq)
+
+type Primitive = String `S` Double `S` Bool
+
+pattern String x = This (This x) :: Primitive
+pattern Double x = This (That x) :: Primitive
+pattern Bool x = That x :: Primitive
 
 -- | Intermediate representation of a flow
 data FlowIR = FlowIR

--- a/src/RVRS/Codegen.hs
+++ b/src/RVRS/Codegen.hs
@@ -1,6 +1,9 @@
 module RVRS.Codegen (generateAiken, prettyPrintFlow) where
 
-import Ya (Recursive (..), unwrap)
+import Data.Bool (bool)
+
+import Ya (Recursive (..), is, unwrap, ho, hu, la, li)
+import qualified Ya as Y
 
 import RVRS.AST
 
@@ -30,10 +33,13 @@ genStmt stmt = case unwrap stmt of
 genExpr :: Recursive Expression -> String
 genExpr expr = case unwrap expr of
   Var x         -> x
-  StrLit s      -> show s
-  BoolLit True  -> "true"
-  BoolLit False -> "false"
+  Lit x   -> genLit x
+  -- StrLit s      -> show s
+  -- BoolLit True  -> "true"
+  -- BoolLit False -> "false"
   Equals a b    -> genExpr a ++ " == " ++ genExpr b
+
+genLit = is @String `ho` show `la` is @Double `ho` show `la` is @Bool `ho` bool "false" "true"
 
 -- | Render a function argument
 renderArg :: Argument -> String

--- a/src/RVRS/Eval.hs
+++ b/src/RVRS/Eval.hs
@@ -18,7 +18,7 @@ import Control.Monad.Reader
 import GHC.IsList (fromList)
 import System.IO (readFile)
 
-import Ya (Recursive (..), unwrap)
+import Ya (Recursive (..), is, unwrap, ho, la, li)
 
 import RVRS.AST
 import RVRS.Env
@@ -116,9 +116,7 @@ binOp op a b = (,) <$> evalExpr a <*> evalExpr b >>= \case
 
 evalExpr :: Recursive Expression -> EvalIR Value
 evalExpr expr = case unwrap expr of
-  NumLit n  -> return $ VNum n
-  StrLit s  -> return $ VStr s
-  BoolLit b -> return $ VBool b
+  Lit x -> return (is @String `ho` VStr `la` is @Double `ho` VNum `la` is @Bool `ho` VBool `li` x)
 
   Var name ->
     Map.lookup name <$> get

--- a/src/RVRS/Parser/ExprParser.hs
+++ b/src/RVRS/Parser/ExprParser.hs
@@ -40,9 +40,9 @@ operatorTable =
 -- Terms in the expression grammar
 term :: Parser (Recursive Expression)
 term = do try $ funcCallExpr
-   <|> do try $ Recursive (BoolLit True) <$ symbol "truth"
-   <|> do try $ Recursive (BoolLit False) <$ symbol "void"
-   <|> do try $ Recursive . StrLit <$> stringLiteral
+   <|> do try $ Recursive (Lit $ Bool True) <$ symbol "truth"
+   <|> do try $ Recursive (Lit $ Bool False) <$ symbol "void"
+   <|> do try $ Recursive . Lit . String <$> stringLiteral
    <|> do try $ parseNumber
    <|> do try $ Recursive . Not <$> (symbol "not" *> term)
    <|> do try $ Recursive . Neg <$> (symbol "-" *> term)
@@ -51,7 +51,7 @@ term = do try $ funcCallExpr
 
 -- Parse numeric literals
 parseNumber :: Parser (Recursive Expression)
-parseNumber = Recursive <$> NumLit <$> do lexeme $ try L.float <|> fromInteger <$> L.decimal
+parseNumber = Recursive . Lit <$> Double <$> do lexeme $ try L.float <|> fromInteger <$> L.decimal
 
 -- Function call expressions (e.g., fuse(2, 3))
 funcCallExpr :: Parser (Recursive Expression)

--- a/src/RVRS/Pretty.hs
+++ b/src/RVRS/Pretty.hs
@@ -1,15 +1,13 @@
 module RVRS.Pretty (prettyExpr) where
 
-import Ya (Recursive (..))
+import Data.Bool (bool)
+import Ya (Recursive (..), is, ho, li, la)
 
 import RVRS.AST
 
 prettyExpr :: Recursive Expression -> String
 prettyExpr expr = case expr of
-  Recursive (NumLit n) -> show n
-  Recursive (BoolLit True) -> "truth"
-  Recursive (BoolLit False) -> "void"
-  Recursive (StrLit s) -> show s
+  Recursive (Lit x) -> is @String `ho` show `la` is @Double `ho` show `la` is @Bool `ho` bool "false" "true" `li` x
   Recursive (Var name) -> name
 
   Recursive (Add e1 e2) -> "(" ++ prettyExpr e1 ++ " + " ++ prettyExpr e2 ++ ")"

--- a/src/RVRS/Typecheck/Check.hs
+++ b/src/RVRS/Typecheck/Check.hs
@@ -1,15 +1,13 @@
 module RVRS.Typecheck.Check where
 
-import Ya (Recursive (..), unwrap)
+import Ya (Recursive (..), is, unwrap, ha__, hu, la, li)
 import RVRS.AST
 import RVRS.Typecheck.Types
 import qualified Data.Map as Map
 
 typeOfExpr :: TypeEnv -> Recursive Expression -> Either TypeError RVRS_Type
 typeOfExpr env expr = case unwrap expr of
-  NumLit _ -> Right TNum
-  StrLit _ -> Right TStr
-  BoolLit _ -> Right TBool
+  Lit x -> Right (is @String `hu` TStr `la` is @Double `hu` TNum `la` is @Bool `hu` TBool `li` x)
   Var x ->
     case Map.lookup x env of
       Just t  -> Right t

--- a/src/RVRS/Value.hs
+++ b/src/RVRS/Value.hs
@@ -2,15 +2,16 @@
 
 module RVRS.Value (Value(..), Binding(..), valueToType, formatVal) where
 
+import Ya (is, ho, hu, la, li)
+
+import RVRS.AST (Primitive, pattern String, pattern Double, pattern Bool)
 import RVRS.Parser.Type (RVRSType(..))
 
 -- | Values produced during RVRS evaluation
 -- This is the unified Value type used across the interpreter
 -- including expression evaluation and type enforcement.
 data Value
-  = VNum Double
-  | VStr String
-  | VBool Bool
+  = VPrim Primitive
   | VError String
   | VVoid
   | VUnit
@@ -24,18 +25,17 @@ data Binding
 
 -- | Convert a runtime Value to its corresponding RVRSType
 valueToType :: Value -> RVRSType
-valueToType (VNum _)   = TypeNum
-valueToType (VStr _)   = TypeStr
-valueToType (VBool _)  = TypeBool
+valueToType (VPrim x) = is @String `hu` TypeStr `la` is @Double `hu` TypeNum `la` is @Bool `hu` TypeBool `li` x
+valueToType (VPrim (Double _)) = TypeNum
+valueToType (VPrim (String _)) = TypeStr
+valueToType (VPrim (Bool _)) = TypeBool
 valueToType VVoid      = TypeAny
 valueToType (VError _) = TypeAny
 valueToType VUnit      = TypeAny
 
 -- | Format Value into a human-readable string
 formatVal :: Value -> String
-formatVal (VStr s)  = s
-formatVal (VNum n)  = show n
-formatVal (VBool b) = show b
+formatVal (VPrim x) = is @String `la` is @Double `ho` show `la` is @Bool `ho` show `li` x
 formatVal VUnit     = "unit"
 formatVal VVoid     = "void"
 formatVal (VError e)= "error: " ++ e

--- a/src/Ya/Instances.hs
+++ b/src/Ya/Instances.hs
@@ -1,7 +1,15 @@
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
 module Ya.Instances where
 
-import Ya (Recursive (..))
+import Ya (S, P, Object (..), Recursive (..))
 
 deriving instance (Eq (f (Recursive f))) => Eq (Recursive f)
 deriving instance (Show (f (Recursive f))) => Show (Recursive f)
+
+deriving instance (Eq l, Eq r) => Eq (l `P` r)
+deriving instance (Eq l, Eq r) => Eq (l `S` r)
+
+deriving instance (Show l, Show r) => Show (l `P` r)
+deriving instance (Show l, Show r) => Show (l `S` r)


### PR DESCRIPTION
In this PR value-related constructions in `Expression` and `Value` are unified into `Primitive` alias.