### PR TITLE
Trigger PR: Update test outputs and flag pending issues

### DIFF
--- a/app/TestLower.hs
+++ b/app/TestLower.hs
@@ -1,13 +1,12 @@
 module Main where
 
--- 🌊 RVRS Internal Modules
+-- RVRS Internal Modules
 import RVRS.Parser (parseRVRS)
 import RVRS.Lower (mergeAndLower)
 import RVRS.Eval (evalIRFlow)
 import qualified RVRS.AST as AST
--- import qualified RVRS.IR as IR
 
--- 📦 System / Standard Libraries
+-- System / Standard Libraries
 import System.Environment (getArgs)
 import qualified Data.Map as Map
 import Text.Megaparsec (errorBundlePretty)
@@ -20,14 +19,14 @@ main = do
       source <- readFile filename
       case parseRVRS source of
         Left parseErr -> do
-          putStrLn "❌ Parse Error:\n"
+          putStrLn "[FAIL] Parse Error:\n"
           putStrLn (errorBundlePretty parseErr)
         Right flows -> do
           let flowEnv = mergeAndLower flows
-          putStrLn "\n🌊 Evaluation Output:"
+          putStrLn "\n[INFO] Evaluation Output:"
           result <- evalIRFlow flowEnv "main" []
           case result of
-            Left err -> putStrLn $ "❌ Evaluation error: " ++ show err
-            Right (Just val) -> putStrLn $ "✅ Returned: " ++ show val
-            Right Nothing -> putStrLn "(✅ Flow completed with no return)"
+            Left err -> putStrLn $ "[FAIL] Evaluation error: " ++ show err
+            Right (Just val) -> putStrLn $ "[PASS] Returned: " ++ show val
+            Right Nothing -> putStrLn "[PASS] Flow completed with no return"
     _ -> putStrLn "Usage: testlower <file>.rvrs"

--- a/app/TestTypeCheck.hs
+++ b/app/TestTypeCheck.hs
@@ -73,6 +73,6 @@ tests = TestList
 
 main :: IO ()
 main = do
-  putStrLn "🔍 Running expression tests..."
+  putStrLn "[TEST] Running expression typecheck tests..."
   _ <- runTestTT tests
   return ()

--- a/app/TestTypeCheckNegative.hs
+++ b/app/TestTypeCheckNegative.hs
@@ -3,7 +3,8 @@ module Main where
 import Test.HUnit
 import qualified Data.Map as Map
 
-import Ya (Recursive(..), pattern Unit, pattern Error, pattern Valid)
+import Ya (Recursive(..), pattern Unit, pattern Error, pattern Valid, ho, ho'ho)
+import Ya.Instances ()
 
 import RVRS.AST
 import RVRS.Checker
@@ -16,42 +17,42 @@ testEnv = Map.fromList
   , ("msg", String Unit)
   ]
 
--- Helpers
+-- Helpers using Ya visual composition
 num :: Double -> Recursive Expression
-num = Recursive . Literal . Double
+num = Double `ho` Literal `ho` Recursive
 
 bool :: Bool -> Recursive Expression
-bool = Recursive . Literal . Bool
+bool = Bool `ho` Literal `ho` Recursive
 
 str :: String -> Recursive Expression
-str = Recursive . Literal . String
+str = String `ho` Literal `ho` Recursive
 
 var :: String -> Recursive Expression
-var = Recursive . Variable
+var = Variable `ho` Recursive
 
 add :: Recursive Expression -> Recursive Expression -> Recursive Expression
-add a b = Recursive (Operator (Binary (Add a b)))
+add = Add `ho'ho` Binary `ho'ho` Operator `ho'ho` Recursive
 
 eq :: Recursive Expression -> Recursive Expression -> Recursive Expression
-eq a b = Recursive (Operator (Binary (Equals a b)))
+eq = Equals `ho'ho` Binary `ho'ho` Operator `ho'ho` Recursive
 
 -- Negative test cases (expected to fail)
 testBadAddBoolNum :: Test
 testBadAddBoolNum = TestCase $
   case expression testEnv (add (bool True) (num 1)) of
-    Error _ -> return ()  -- ✅ expected failure
+    Error _ -> return ()
     Valid t -> assertFailure $ "Unexpected success: got " ++ show t
 
 testBadEqNumStr :: Test
 testBadEqNumStr = TestCase $
   case expression testEnv (eq (num 5) (str "five")) of
-    Error _ -> return ()  -- ✅ expected failure
+    Error _ -> return ()
     Valid t -> assertFailure $ "Unexpected success: got " ++ show t
 
 testBadVarUnbound :: Test
 testBadVarUnbound = TestCase $
   case expression testEnv (var "z") of
-    Error _ -> return ()  -- ✅ expected failure
+    Error _ -> return ()
     Valid t -> assertFailure $ "Unexpected success: got " ++ show t
 
 testBadNestedAdd :: Test
@@ -63,7 +64,7 @@ testBadNestedAdd = TestCase $
 -- Main runner
 main :: IO ()
 main = do
-  putStrLn "🔍 Running negative expression tests..."
+  putStrLn "[TEST] Running negative expression typecheck tests..."
   _ <- runTestTT $ TestList
     [ testBadAddBoolNum
     , testBadEqNumStr

--- a/rvrs-lang.cabal
+++ b/rvrs-lang.cabal
@@ -153,6 +153,7 @@ executable TestTypeCheck
       RVRS.AST
     , RVRS.Parser.Type
     , RVRS.Checker
+    , RVRS.Value
     , Ya.Conversion
     , Ya.Instances
 
@@ -161,6 +162,9 @@ executable testtypechecknegative
   main-is: TestTypeCheckNegative.hs
   other-modules:
       RVRS.AST
-    , RVRS.Parser.Type
     , RVRS.Checker
+    , RVRS.Parser.Type
+    , RVRS.Utils
+    , RVRS.Value
+    , Ya.Conversion
     , Ya.Instances

--- a/tests/edge_cases/whisper_test.rvrs
+++ b/tests/edge_cases/whisper_test.rvrs
@@ -1,3 +1,5 @@
+-- whisper test 
+
 flow main() {
   delta x = 4
   delta y = (x + 6)

--- a/tests/edge_cases/whisper_test.rvrs
+++ b/tests/edge_cases/whisper_test.rvrs
@@ -1,5 +1,7 @@
 flow main() {
   delta x = 4
   delta y = (x + 6)
-  whisper (y * 2)
+  delta result = (y * 2)
+  echo result
+  whisper result
 }

--- a/tests/edge_cases/whisper_test.rvrs
+++ b/tests/edge_cases/whisper_test.rvrs
@@ -8,4 +8,3 @@ flow main() {
   whisper result
 }
 
-# SSH signature test

--- a/tests/edge_cases/whisper_test.rvrs
+++ b/tests/edge_cases/whisper_test.rvrs
@@ -1,4 +1,4 @@
--- whisper test 
+-- whisper test!
 
 flow main() {
   delta x = 4
@@ -7,3 +7,5 @@ flow main() {
   echo result
   whisper result
 }
+
+# SSH signature test


### PR DESCRIPTION
This commit updates the test outputs across all runners (RunAll, RunIRTests, TestLower, TestTypeCheck, TestTypeCheckNegative) to reflect the current state of evaluation and typechecking.

The goal is to trigger a pull request and prepare for the next iteration of work. 

---

Pending Tasks:

- [x] Silent Test: \whisper_test.rvrs\ produces no output — verify expected behavior.
- [x] Module Warning: \RVRS.Value\ needs to be added to \other-modules\ in the Cabal file for full compliance.
- [x] Type Test Failure: \Not on Num\ test in \TestTypeCheck.hs\ expects a \Mismatched\ error, but the checker returns \Unexpected\. Need to align error types or update test expectation.

All other tests are passing as of this commit.